### PR TITLE
Catch errors from http(s) request, will throw globally otherwise.

### DIFF
--- a/node.js/pubnub.js
+++ b/node.js/pubnub.js
@@ -1063,6 +1063,7 @@ function xdr( setup ) {
                 finished();
             });
         });
+        request.on( 'error', function(){done(1, { "error" : "Network Connection Error"})});
         request.end();
         request.timeout = xhrtme;
 


### PR DESCRIPTION
An error from the sending a request (such as a ECONNRESET), will throw a global exception.
