### PR TITLE
extend isArray helper

### DIFF
--- a/core/pubnub-common.js
+++ b/core/pubnub-common.js
@@ -129,7 +129,7 @@ function uuid(callback) {
 }
 function isArray(arg) {
     var type = Object.prototype.toString.call(arg);
-    return   ( type === "[object Array]" || type === "[object NodeList]");
+    return   ( type === "[object Array]" || type === "[object NodeList]" || type === "[object ScriptBridgingArrayProxyObject]");
 }
 
 /**


### PR DESCRIPTION
To ensure correct AIR functionality we need to extend isArray helper so it detects ActionScript arrays.
