### PR TITLE
Fixed comment related to PAM TTL

### DIFF
--- a/core/pubnub-common.js
+++ b/core/pubnub-common.js
@@ -765,7 +765,7 @@ function PN_API(setup) {
                 channel  : 'my_chat',
                 callback : fun,
                 error    : fun,
-                ttl      : 60, // Seconds
+                ttl      : 24 * 60, // Minutes
                 read     : true,
                 write    : true,
                 auth_key : '3y8uiajdklytowsj'


### PR DESCRIPTION
According to the docs and how it works in the test console this parameter is expressed in minutes, with a default of 24 \* 60 = 1440 minutes

http://www.pubnub.com/docs/javascript/api/reference.html#grant
