### PR TITLE
Fix PubNub in iframe with 3rd party cookies disabled

### DIFF
--- a/modern/unassembled/platform.js
+++ b/modern/unassembled/platform.js
@@ -42,7 +42,18 @@ var NOW        = 1
  * LOCAL STORAGE
  */
 var db = (function(){
-    var ls = typeof localStorage != 'undefined' && localStorage;
+    try {
+        var ls = typeof localStorage != 'undefined' && localStorage;
+    } catch (e) {
+        var ls = {
+            _data       : {},
+            setItem     : function(id, val) { return this._data[id] = String(val); },
+            getItem     : function(id) { return this._data.hasOwnProperty(id) ? this._data[id] : undefined; },
+            removeItem  : function(id) { return delete this._data[id]; },
+            clear       : function() { return this._data = {}; }
+        }
+    }
+
     return {
         get : function(key) {
             try {

--- a/web/pubnub.js
+++ b/web/pubnub.js
@@ -2659,17 +2659,7 @@ console.log    || (
  * LOCAL STORAGE OR COOKIE
  */
 var db = (function(){
-    try {
-        var ls = window['localStorage'];
-    } catch (e) {
-        var ls = {
-            _data       : {},
-            setItem     : function(id, val) { return this._data[id] = String(val); },
-            getItem     : function(id) { return this._data.hasOwnProperty(id) ? this._data[id] : undefined; },
-            removeItem  : function(id) { return delete this._data[id]; },
-            clear       : function() { return this._data = {}; }
-        }
-    }
+    var ls = window['localStorage'];
 
     return {
         'get' : function(key) {

--- a/web/unassembled/platform.js
+++ b/web/unassembled/platform.js
@@ -30,7 +30,17 @@ console.log    || (
  * LOCAL STORAGE OR COOKIE
  */
 var db = (function(){
-    var ls = window['localStorage'];
+    try {
+        var ls = window['localStorage'];
+    } catch (e) {
+        var ls = {
+            _data       : {},
+            setItem     : function(id, val) { return this._data[id] = String(val); },
+            getItem     : function(id) { return this._data.hasOwnProperty(id) ? this._data[id] : undefined; },
+            removeItem  : function(id) { return delete this._data[id]; },
+            clear       : function() { return this._data = {}; }
+        }
+    }
     return {
         'get' : function(key) {
             try {


### PR DESCRIPTION
If PubNub is used in an iframe with 3rd party cookies disabled, it currently throws the following error:

`Uncaught SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.`

To fix this, we wrap the access of the `localStorage` object in a try/catch and polyfill if necessary.
