### PR TITLE
expose isArray function

### DIFF
--- a/core/pubnub-common.js
+++ b/core/pubnub-common.js
@@ -1274,6 +1274,7 @@ function PN_API(setup) {
         'uuid'          : uuid,
         'map'           : map,
         'each'          : each,
+        'isArray'       : isArray,
         'each-channel'  : each_channel,
         'grep'          : grep,
         'offline'       : function(){_reset_offline(1, { "message":"Offline. Please check your network settings." })},


### PR DESCRIPTION
PUBNUB.isArray function would be useful for the code snippet below since this accounts for the Array-like arguments object. I would normally use isArray method on the Array constructor which doesn't account for arguments object edge case

``` javascript
PUBNUB._publish = PUBNUB.publish;
PUBNUB.publish = function(body) {
  var channels = body.channel;
  if (typeof channels === 'string' && (/,/i).test(channels)) {
    this.publish(channels.split(','));
  } else if (this.isArray(channels)) {
    this.each(Array.prototype.slice.call(channels, 0), function(channel) {
      body.channel = channel;
      this.publish(body);
    });
  } else {
    this._publish(body);
  }
};
```
