### PR TITLE
Fixed script tags missing quotes and improper format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ You may access the latest PubNub JavaScript SDK on The PubNub Network CDN.
 
 ```html
 <!-- Versioned SDK "Static" -->
-<script src=http://cdn.pubnub.com/pubnub-3.6.6.min.js ></script>
+<script src='http://cdn.pubnub.com/pubnub-3.6.6.min.js'></script>
 
 <!-- Latest SDK "Auto Upgrading" -->
-<script src=http://cdn.pubnub.com/pubnub.min.js ></script>
+<script src='http://cdn.pubnub.com/pubnub.min.js'></script>
 
 <!-- SSL Works Too! -->
-<script src=https://cdn.pubnub.com/pubnub.min.js ></script>
+<script src='https://cdn.pubnub.com/pubnub.min.js'></script>
 ```
 
 >**NOTE:** SSL Mode requires a few extra steps: [SSL MODE](README.md#ssl-mode)
@@ -33,7 +33,7 @@ You may access the latest PubNub JavaScript SDK on The PubNub Network CDN.
 Init Method to Create PubNub Instance:
 
 ```html
-<script src=http://cdn.pubnub.com/pubnub-3.6.6.min.js ></script>
+<script src='http://cdn.pubnub.com/pubnub-3.6.6.min.js'></script>
 <script>(function(){
     var pubnub = PUBNUB.init({
         publish_key   : 'demo',
@@ -71,7 +71,7 @@ and for security considerations,
 use this following method for initialization:
 
 ```html
-<script src=http://cdn.pubnub.com/pubnub-3.6.6.min.js ></script>
+<script src='http://cdn.pubnub.com/pubnub-3.6.6.min.js'></script>
 <script>(function(){
     
     var pubnub = PUBNUB.init({ subscribe_key : 'demo' });
@@ -84,7 +84,7 @@ use this following method for initialization:
 >**NOTE:** Copy and paste this example into a *blank* HTML file or visit http://jsfiddle.net/geremy/SqamR/ to demo
 
 ```html
-<script src=http://cdn.pubnub.com/pubnub-3.6.6.min.js ></script>
+<script src='http://cdn.pubnub.com/pubnub-3.6.6.min.js'></script>
 <script>(function(){
 
     // Init
@@ -200,7 +200,7 @@ JavaScript SDK using the **web** build.  It's as easy as `copy/paste`.
 ## ADVANCED SUBSCRIBE CONNECTIVITY OPTIONS/CALLBACKS
 ```html
 <div id=pubnub pub-key=demo sub-key=demo></div>
-<script src=http://cdn.pubnub.com/pubnub-3.6.6.min.js ></script>
+<script src='http://cdn.pubnub.com/pubnub-3.6.6.min.js' ></script>
 <script>(function(){
     PUBNUB.subscribe({
         channel    : "hello_world",                        // CONNECT TO THIS CHANNEL.
@@ -248,7 +248,7 @@ when **receiving messages**.
 
 ```html
 <div id=pubnub pub-key=demo sub-key=demo></div>
-<script src=http://cdn.pubnub.com/pubnub-3.6.6.min.js ></script>
+<script src='http://cdn.pubnub.com/pubnub-3.6.6.min.js'></script>
 <script>(function(){
     PUBNUB.subscribe({
         channel : "hello_world",                        // CONNECT TO THIS CHANNEL.
@@ -362,7 +362,7 @@ are open source, you’re welcome to see how we did it).
 To use AES encryption in PubNub, simply do the following:
 
 ```html
-<script src=https://pubnub.a.ssl.fastly.net/pubnub-3.6.6.min.js></script>
+<script src='https://pubnub.a.ssl.fastly.net/pubnub-3.6.6.min.js'></script>
 <script>(function(){
     var secure_pubnub = PUBNUB.init({
         publish_key   : 'demo',
@@ -429,7 +429,7 @@ http://jsfiddle.net/geremy/8e6Cr/
 ## SSL MODE
 ```html
 <div id=pubnub ssl=on></div>
-<script src=https://pubnub.a.ssl.fastly.net/pubnub-3.6.6.min.js></script>
+<script src='https://pubnub.a.ssl.fastly.net/pubnub-3.6.6.min.js'></script>
 <script>(function(){
 
     var pubnub = PUBNUB.init({
@@ -566,7 +566,7 @@ http://pubsub.pubnub.com/v2/history/sub-key/demo/channel/storage_test?start=1340
 ## HISTORY
 ```html
 <div id=pubnub></div>
-<script src=http://pubnub.a.ssl.fastly.net/pubnub-3.6.6.min.js></script>
+<script src='http://pubnub.a.ssl.fastly.net/pubnub-3.6.6.min.js'></script>
 <script>(function(){
 
     var pubnub = PUBNUB.init({
@@ -595,7 +595,7 @@ the timeline as they occured.
 
 ```html
 <div id=pubnub></div>
-<script src=http://pubnub.a.ssl.fastly.net/pubnub-3.6.6.min.js></script>
+<script src='http://pubnub.a.ssl.fastly.net/pubnub-3.6.6.min.js'></script>
 <script>(function(){
 
 /* GENERATE CHANNEL */
@@ -632,7 +632,7 @@ and get back an answer with list of users and the occupancy count.
 
 ```html
 <div id=pubnub pub-key=demo sub-key=demo></div>
-<script src=http://cdn.pubnub.com/pubnub-3.6.6.min.js ></script>
+<script src='http://cdn.pubnub.com/pubnub-3.6.6.min.js'></script>
 <script>(function(){
     PUBNUB.subscribe({
         channel    : "hello_world",                        // CONNECT TO THIS CHANNEL.
@@ -674,7 +674,7 @@ the `pubnub.subscribe` call below.
 
 ```html
 <div id=pubnub></div>
-<script src=http://pubnub.a.ssl.fastly.net/pubnub-3.6.6.min.js></script>
+<script src='http://pubnub.a.ssl.fastly.net/pubnub-3.6.6.min.js'></script>
 <script>(function(){
 
     var pubnub = PUBNUB.init({
@@ -791,7 +791,7 @@ How to create a new instance of the PubNub Object directly in JavaScript.
 To do this, simply follow this `init` example:
 
 ```html
-<script src=http://cdn.pubnub.com/pubnub-3.6.6.min.js ></script>
+<script src='http://cdn.pubnub.com/pubnub-3.6.6.min.js'></script>
 <script>(function(){
 
     // INIT PubNub
@@ -835,7 +835,7 @@ will want to use `noleave` option:
 Use the following setup commands to enable `noleave`.
 
 ```html
-<script src=http://cdn.pubnub.com/pubnub-3.6.6.min.js ></script>
+<script src='http://cdn.pubnub.com/pubnub-3.6.6.min.js'></script>
 <script>(function(){
 
     // INIT PubNub

--- a/examples/audio-mosaic/audio-mosaic.html
+++ b/examples/audio-mosaic/audio-mosaic.html
@@ -2,26 +2,26 @@
 <html>
 <head>
     <title>PubNub Audio Mosaic</title>
-    <link href=audio-mosaic.css rel=stylesheet type=text/css >
+    <link href='audio-mosaic.css rel=stylesheet type=text/css'>
     <link
-        href=http://fonts.googleapis.com/css?family=Bowlby+One+SC|Didact+Gothic&v2
-        rel=stylesheet
-        type=text/css
+        href='http://fonts.googleapis.com/css?family=Bowlby+One+SC|Didact+Gothic&v2'
+        rel='stylesheet'
+        type='text/css'
     >
 </head>
-<body><div class=stage>
+<body><div class='stage'>
 
-<audio id=audio preload >
-    <source src=http://pubnub.s3.amazonaws.com/general/SkullCat-Unmastered-8bc.mp3 type=audio/mp3 >
-    <source src=http://pubnub.s3.amazonaws.com/general/SkullCat-Unmastered-8bc.ogg type=audio/ogg >
+<audio id='audio preload' >
+    <source src='http://pubnub.s3.amazonaws.com/general/SkullCat-Unmastered-8bc.mp3' type='audio/mp3'>
+    <source src='http://pubnub.s3.amazonaws.com/general/SkullCat-Unmastered-8bc.ogg' type='audio/ogg'>
 </audio>
 
-<div id=timer></div>
-<div id=audio-mosaic>Audio Mosaic</div>
-<div id=userlist></div>
+<div id='timer'></div>
+<div id='audio-mosaic'>Audio Mosaic</div>
+<div id='userlist'></div>
 
-<div id=pubnub pub-key=demo sub-key=demo></div>
-<script src=../../web/pubnub.min.js></script>
-<script src=audio-mosaic.js></script>
+<div id='pubnub' pub-key='demo' sub-key='demo'></div>
+<script src='../../web/pubnub.min.js'></script>
+<script src='audio-mosaic.js'></script>
 </div></body>
 </html>

--- a/examples/chat-with-sounds/chat.html
+++ b/examples/chat-with-sounds/chat.html
@@ -2,12 +2,12 @@
 
 Enter Chat and press enter
 
-<div><input id=input placeholder=chat-here></div>
+<div><input id='input' placeholder='chat-here'></div>
 <code>Chat Output</code>
-<div id=box></div>
-<div id=pubnub pub-key=demo sub-key=demo></div>
-<script src=../../web/pubnub.min.js></script>
-<script src=sound.js></script>
+<div id='box'></div>
+<div id='pubnub' pub-key='demo' sub-key='demo'></div>
+<script src='../../web/pubnub.min.js'></script>
+<script src='sound.js'></script>
 <script>(function(){
     var box = PUBNUB.$('box'), input = PUBNUB.$('input'), channel = 'chatlllll';
     PUBNUB.subscribe({


### PR DESCRIPTION
It seems that some script tags were missing quotes when including pubnub src. As a user it is desirable to see correctly formatted source tags.
