### PR TITLE
Replacing Ti.Include with require

### DIFF
--- a/titanium/README.md
+++ b/titanium/README.md
@@ -15,7 +15,7 @@ https://vimeo.com/57166260
 ### Init
 
 ```javascript
-Ti.include('pubnub.js');
+PUBNUB = require('pubnub.js');
 
 var pubnub = PUBNUB({
     publish_key       : 'demo',


### PR DESCRIPTION
Ti.Include is deprecated and will soon be removed.

The `pubnub.js` library itself already supports the CommonJS interface.