### PR TITLE
Fixed a cut-and-paste issue that broke channel_group subscriptions

### DIFF
--- a/core/pubnub-common.js
+++ b/core/pubnub-common.js
@@ -198,7 +198,7 @@ function generate_channel_groups_list(channel_groups, nopresence) {
     var list = [];
     each(channel_groups, function( channel_group, status ) {
         if (nopresence) {
-            if(channel.search('-pnpres') < 0) {
+            if(channel_group.search('-pnpres') < 0) {
                 if (status.subscribed) list.push(channel_group);
             }
         } else {


### PR DESCRIPTION
Seems like there was a small amount of cut-and-paste-itus - renamed channel to channel_group to prevent exceptions and get stuff working (I think)