### PR TITLE
fix(LEAVE): blocking calls with SSL

### DIFF
--- a/core/pubnub-common.js
+++ b/core/pubnub-common.js
@@ -512,7 +512,7 @@ function PN_API(setup) {
             if (jsonp != '0') data['callback'] = jsonp;
 
             xdr({
-                blocking : blocking || SSL,
+                blocking : blocking,
                 timeout  : 2000,
                 callback : jsonp,
                 data     : _get_url_params(data),


### PR DESCRIPTION
I'm not sure why there is a blocking feature if you're setting it to false both times. If blocking is necessary then making one request for multiple channels would help