### PR TITLE
fix(web): platform.js ie <= 9

### DIFF
--- a/web/unassembled/platform.js
+++ b/web/unassembled/platform.js
@@ -149,7 +149,7 @@ function unbind( type, el, fun ) {
  * ====
  * head().appendChild(elm);
  */
-function head() { return search('head')[0] }
+function head() { return document.getElementsByTagName('head')[0] }
 
 /**
  * ATTR


### PR DESCRIPTION
IE<=9 search returns a string rather than the element

![screen shot 2014-12-10 at 5 51 43 pm](https://cloud.githubusercontent.com/assets/1016365/5387920/9467ce74-8096-11e4-8852-bafd3d2faf95.png)