### PR TITLE
Avoid "cannot read property of null" exception after a disconnect.

### DIFF
--- a/node.js/pubnub.js
+++ b/node.js/pubnub.js
@@ -1300,7 +1300,7 @@ function PN_API(setup) {
                     timeout  : sub_timeout,
                     callback : jsonp,
                     fail     : function(response) {
-                        if (response['error'] && response['service']) {
+                        if (typeof response == 'object' && response['error'] && response['service']) {
                             _invoke_error(response, errcb);
                             _test_connection(1);
                         } else {


### PR DESCRIPTION
The common idiom of done(1) in the SDK results in the fail callback being called with a null response parameter.  This change avoids generating an exception in this case.