### PR TITLE
add defensive response check in subscription fail callback

### DIFF
--- a/core/pubnub-common.js
+++ b/core/pubnub-common.js
@@ -1299,7 +1299,7 @@ function PN_API(setup) {
                     timeout  : sub_timeout,
                     callback : jsonp,
                     fail     : function(response) {
-                        if (response['error'] && response['service']) {
+                        if (response && response['error'] && response['service']) {
                             _invoke_error(response, errcb);
                             _test_connection(1);
                         } else {


### PR DESCRIPTION
Not very familiar with the code, but sometimes we were getting `undefined` responses. There could be no harm with defensive checks :) 