### PR TITLE
Normalize error messages

### DIFF
--- a/node.js/unassembled/platform.js
+++ b/node.js/unassembled/platform.js
@@ -104,7 +104,7 @@ function xdr( setup ) {
 
             clearTimeout(timer);
             try       { response = JSON['parse'](body); }
-            catch (r) { return done(1); }
+            catch (r) { return done(1, {"message" : "Parse Error", "payload" : body); }
             success(response);
         }
     ,   done    = function(failed, response) {
@@ -122,7 +122,7 @@ function xdr( setup ) {
             }
             failed && fail(response);
         }
-        ,   timer  = timeout( function(){done(1);} , xhrtme );
+        ,   timer  = timeout( function(){done(1, {"message" : "Timeout"});} , xhrtme );
 
     data['pnsdk'] = PNSDK;
 
@@ -159,8 +159,8 @@ function xdr( setup ) {
     try {
         request = (ssl ? https : http)['request'](options, function(response) {
             response.setEncoding('utf8');
-            response.on( 'error', function(){done(1, body || { "error" : "Network Connection Error"})});
-            response.on( 'abort', function(){done(1, body || { "error" : "Network Connection Error"})});
+            response.on( 'error', function(){done(1, { "message" : "Response Error", "payload" : body})});
+            response.on( 'abort', function(){done(1, { "message" : "Response Abort", "payload" : body})});
             response.on( 'data', function (chunk) {
                 if (chunk) body += chunk;
             } );
@@ -175,7 +175,7 @@ function xdr( setup ) {
                             response = JSON['parse'](body);
                             done(1,response);
                         }
-                        catch (r) { return done(1, {status : statusCode, payload : null, message : body}); }
+                        catch (r) { return done(1, {"status" : statusCode, "message" : "Parse Error", "payload" : body}); }
                         return;
                 }
                 finished();
@@ -183,7 +183,7 @@ function xdr( setup ) {
         });
         request.timeout = xhrtme;
         request.on( 'error', function() {
-            done( 1, {"error":"Network Connection Error"} );
+            done( 1, {"message" : "Network Connection Error"} );
         } );
 
         if (mode == 'POST') request.write(payload);

--- a/web/unassembled/platform.js
+++ b/web/unassembled/platform.js
@@ -235,7 +235,7 @@ function xdr( setup ) {
     ,   id        = unique()
     ,   finished  = 0
     ,   xhrtme    = setup.timeout || DEF_TIMEOUT
-    ,   timer     = timeout( function(){done(1, {"message" : "timeout"})}, xhrtme )
+    ,   timer     = timeout( function(){done(1, {"message" : "Timeout"})}, xhrtme )
     ,   fail      = setup.fail    || function(){}
     ,   data      = setup.data    || {}
     ,   success   = setup.success || function(){}
@@ -250,7 +250,7 @@ function xdr( setup ) {
             (failed || !response) || success(response);
 
             timeout( function() {
-                failed && fail();
+                failed && fail(response);
                 var s = $(id)
                 ,   p = s && s.parentNode;
                 p && p.removeChild(s);
@@ -263,7 +263,7 @@ function xdr( setup ) {
 
     if (!setup.blocking) script[ASYNC] = ASYNC;
 
-    script.onerror = function() { done(1) };
+    script.onerror = function() { done(1, {"message" : "Network Connection Error"}) };
     script.src     = build_url( setup.url, data );
 
     attr( script, 'id', id );
@@ -290,7 +290,7 @@ function ajax( setup ) {
             clearTimeout(timer);
 
             try       { response = JSON['parse'](xhr.responseText); }
-            catch (r) { return done(1); }
+            catch (r) { return done(1, {"message" : "Parse Error", "payload" : xhr.responseText}); }
 
             complete = 1;
             success(response);
@@ -298,7 +298,7 @@ function ajax( setup ) {
     ,   complete = 0
     ,   loaded   = 0
     ,   xhrtme   = setup.timeout || DEF_TIMEOUT
-    ,   timer    = timeout( function(){done(1, {"message" : "timeout"})}, xhrtme )
+    ,   timer    = timeout( function(){done(1, {"message" : "Timeout"})}, xhrtme )
     ,   fail     = setup.fail    || function(){}
     ,   data     = setup.data    || {}
     ,   success  = setup.success || function(){}
@@ -326,7 +326,7 @@ function ajax( setup ) {
               new XMLHttpRequest();
 
         xhr.onerror = xhr.onabort   = function(e){ done(
-            1, e || (xhr && xhr.responseText) || { "error" : "Network Connection Error"}
+            1, e || (xhr && xhr.responseText) || {"message" : "Network Connection Error"}
         ) };
         xhr.onload  = xhr.onloadend = finished;
         xhr.onreadystatechange = function() {
@@ -339,7 +339,7 @@ function ajax( setup ) {
                             response = JSON['parse'](xhr.responseText);
                             done(1,response);
                         }
-                        catch (r) { return done(1, {status : xhr.status, payload : null, message : xhr.responseText}); }
+                        catch (r) { return done(1, {"status" : xhr.status, "message" : "Parse Error", "payload" : xhr.responseText}); }
                         return;
                 }
             }


### PR DESCRIPTION
- "error" key should be "message"
- "payload" should never be null
- JSON parse errors are clearly labeled, and include the unparsed payload
- Timeout errors are clearly labeled
- Aborted connections include the payload received so far