### PR TITLE
xhr might be null on the try-catch

### DIFF
--- a/web/pubnub.js
+++ b/web/pubnub.js
@@ -2661,11 +2661,13 @@ function ajax( setup ) {
                     case 200:
                         break;
                     default:
+                        var responseText = xhr.responseText;
+                        var status = xhr.status;
                         try {
-                            response = JSON['parse'](xhr.responseText);
+                            response = JSON['parse'](responseText);
                             done(1,response);
                         }
-                        catch (r) { return done(1, {status : xhr.status, payload : null, message : xhr.responseText}); }
+                        catch (r) { return done(1, {status : status, payload : null, message : responseText}); }
                         return;
                 }
             }


### PR DESCRIPTION
in the `done` function, if `failed` callback throws an exception, the `catch` will execute, but `xhr` would have already been nulled out, causing an exception to occur during exception handling