### PR TITLE
Support react-native projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "codecov": "cat coverage/lcov.info | codecov"
   },
   "main": "./lib/node/index.js",
+  "react-native": "./lib/node/index.js",
   "browser": "./dist/web/pubnub.min.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
See [react native's packager code](https://github.com/facebook/react-native/blob/7d27f4941cf9fa0782dd9fd345b8e7ae507477e2/packager/react-packager/src/node-haste/Package.js#L110-L132) - react native's packager uses the browser field in `package.json` if there's no `react-native` field, but the browser entry point relies on things like `localStorage` and `window`, which are not available in React Native. The node version should be used instead.