### PR TITLE
Fix undefined chobj

### DIFF
--- a/core/src/pubnub-common.js
+++ b/core/src/pubnub-common.js
@@ -1468,15 +1468,16 @@ function PN_API(setup) {
                 var channel2 = list2.shift();
 
                 var chobj = {};
+                var default_chobj = { callback: function () {} };
 
                 if (channel2) {
                   if (channel && channel.indexOf('-pnpres') >= 0
                     && channel2.indexOf('-pnpres') < 0) {
                     channel2 += '-pnpres';
                   }
-                  chobj = CHANNEL_GROUPS[channel2] || CHANNELS[channel2] || { callback: function () {} };
+                  chobj = CHANNEL_GROUPS[channel2] || CHANNELS[channel2] || default_chobj;
                 } else {
-                  chobj = CHANNELS[channel];
+                  chobj = CHANNELS[channel] || default_chobj;
                 }
 
                 var r = [


### PR DESCRIPTION
We're getting an error of ```Cannot read property 'callback' of undefined``` which is caused by lines 1483-1484 in core/src/pubnub-common.js. 

I believe it is caused because ```chobj``` is set to undefined because there is not an entry in the ```CHANNELS``` list that corresponds to ```channel```. 