### PR TITLE
return promise from setState endpoint

### DIFF
--- a/src/core/components/subscription_manager.js
+++ b/src/core/components/subscription_manager.js
@@ -104,7 +104,7 @@ export default class {
       if (channelGroup in this._channelGroups) this._channelGroups[channelGroup].state = state;
     });
 
-    this._setStateEndpoint({ state, channels, channelGroups }, callback);
+    return this._setStateEndpoint({ state, channels, channelGroups }, callback);
   }
 
   adaptSubscribeChange(args: SubscribeArgs) {

--- a/test/integration/operations/stateSetting.test.js
+++ b/test/integration/operations/stateSetting.test.js
@@ -78,5 +78,20 @@ describe('setting state operation', () => {
         done();
       });
     });
+
+    it('supports promises', (done) => {
+      const scope = utils.createNock().get('/v2/presence/sub-key/mySubscribeKey/channel/ch1/uuid/myUUID/data')
+        .query({ pnsdk: 'PubNub-JS-Nodejs/' + pubnub.getVersion(), uuid: 'myUUID', state: '{"hello":"there"}' })
+        .reply(200, '{ "status": 200, "message": "OK", "payload": { "age" : 20, "status" : "online" }, "service": "Presence"}');
+
+      let promise = pubnub.setState({ channels: ['ch1'], state: { hello: 'there' } });
+      assert.ok(promise);
+      assert(typeof promise.then === 'function');
+      promise.then((response) => {
+        assert.deepEqual(response.state, { age: 20, status: 'online' });
+        assert.equal(scope.isDone(), true);
+        done();
+      }).catch(done);
+    });
   });
 });


### PR DESCRIPTION
The changelog for v4.2.0 lists "Add optional support for promises on all endpoints."

The documentation for what returns promises is basically non-existent, but I received an error when trying to do this:

```
pubnub.setState({ channels: ['my_channel'], state: { 'isTyping': 'true' } }).then((res) => { console.log(res); });
```

The error I get is "EXCEPTION: Cannot read property 'then' of undefined", because pubnub.setState() doesn't return a promise like the hereNow(), whereNow(), and getState() endpoints.

After digging into the source a bit, I realized that the reason the function is not returning the promise is that the call to the endpoint built by the util is not actually being returned by [_subsctiptionManager.adaptStateChange(), here](https://github.com/pubnub/javascript/blob/master/src/core/components/subscription_manager.js#L107), which should instead be this:
```
return this._setStateEndpoint({ state, channels, channelGroups }, callback);
```

I also added an integration test to `stateSetting.test.js` to ensure that the promises succeed.