### PR TITLE
Return publish in fire (allows promise)

### DIFF
--- a/src/core/pubnub-common.js
+++ b/src/core/pubnub-common.js
@@ -163,7 +163,7 @@ export default class {
     this.fire = (args, callback) => {
       args.replicate = false;
       args.storeInHistory = false;
-      this.publish(args, callback);
+      return this.publish(args, callback);
     };
 
     this.history = endpointCreator.bind(this, modules, historyEndpointConfig);


### PR DESCRIPTION
Because the publish method wasn't returned, we couldn't do:

```js
   pubnub.fire({ ... }).then(() => ...)
```