### PR TITLE
Be secure by default

### DIFF
--- a/src/core/components/config.js
+++ b/src/core/components/config.js
@@ -129,7 +129,7 @@ export default class {
     this.setFilterExpression(setup.filterExpression);
 
     this.origin = setup.origin || 'pubsub.pubnub.com';
-    this.secure = setup.ssl || false;
+    this.secure = setup.ssl || true;
     this.restore = setup.restore || false;
     this.proxy = setup.proxy;
     this.keepAlive = setup.keepAlive;


### PR DESCRIPTION
Following the secure by default[1] software practice, use an encrypted transport by default.

In the current form, any pubnub user with default settings will have their data exposed to network eavesdroppers.

In the same spirit as https://github.com/pubnub/javascript/commit/2de9ec1b04da9d8545944cc6bee3ead61655f1ba

[1] https://en.wikipedia.org/wiki/Secure_by_default