### PR TITLE
Custom client/sdk name

### DIFF
--- a/src/core/components/config.js
+++ b/src/core/components/config.js
@@ -28,6 +28,11 @@ export default class {
   instanceId: string;
 
   /*
+    If the SDK is running as part of another SDK built atop of it, allow a custom pnsdk with name and version.
+   */
+  sdkName: string;
+
+  /*
     keep track of the SDK family for identifier generator
   */
   sdkFamily: string;
@@ -130,6 +135,7 @@ export default class {
     this.secretKey = setup.secretKey || setup.secret_key;
     this.subscribeKey = setup.subscribeKey || setup.subscribe_key;
     this.publishKey = setup.publishKey || setup.publish_key;
+    this.sdkName = setup.sdkName;
     this.sdkFamily = setup.sdkFamily;
     this.partnerId = setup.partnerId;
     this.setAuthKey(setup.authKey);

--- a/src/core/components/endpoint.js
+++ b/src/core/components/endpoint.js
@@ -32,6 +32,10 @@ function decideURL(endpoint, modules, incomingParams) {
 }
 
 function generatePNSDK(config: Config): string {
+  if (config.sdkName) {
+    return config.sdkName;
+  }
+
   let base = `PubNub-JS-${config.sdkFamily}`;
 
   if (config.partnerId) {

--- a/test/integration/components/networking.test.js
+++ b/test/integration/components/networking.test.js
@@ -10,6 +10,7 @@ import packageJSON from '../../../package.json';
 describe('#components/networking', () => {
   let pubnub;
   let pubnubPartner;
+  let pubnubSDKName;
 
   before(() => {
     nock.disableNetConnect();
@@ -23,21 +24,36 @@ describe('#components/networking', () => {
     nock.cleanAll();
     pubnub = new PubNub({ subscribeKey: 'mySubKey', publishKey: 'myPublishKey', uuid: 'myUUID' });
     pubnubPartner = new PubNub({ subscribeKey: 'mySubKey', publishKey: 'myPublishKey', uuid: 'myUUID', partnerId: 'alligator' });
+    pubnubSDKName = new PubNub({ subscribeKey: 'mySubKey', publishKey: 'myPublishKey', uuid: 'myUUID', sdkName: 'custom-sdk/1.0.0' });
   });
 
-  describe('supports user-agent generation with partner', () => {
-    it('returns a correct user-agent object', (done) => {
-      utils.createNock().get('/time/0')
-        .query({ uuid: 'myUUID', pnsdk: `PubNub-JS-Nodejs-alligator/${packageJSON.version}` })
-        .reply(200, [14570763868573725]);
+    describe('supports user-agent generation with partner', () => {
+        it('returns a correct user-agent object', (done) => {
+            utils.createNock().get('/time/0')
+                .query({ uuid: 'myUUID', pnsdk: `PubNub-JS-Nodejs-alligator/${packageJSON.version}` })
+                .reply(200, [14570763868573725]);
 
-      pubnubPartner.time((status) => {
-        assert.equal(status.error, false);
-        assert.equal(status.statusCode, 200);
-        done();
-      });
+            pubnubPartner.time((status) => {
+                assert.equal(status.error, false);
+                assert.equal(status.statusCode, 200);
+                done();
+            });
+        });
     });
-  });
+
+    describe('supports PNSDK generation with custom SDK name', () => {
+        it('returns a correct response object', (done) => {
+            utils.createNock().get('/time/0')
+                .query({ uuid: 'myUUID', pnsdk: 'custom-sdk/1.0.0' })
+                .reply(200, [14570763868573725]);
+
+            pubnubSDKName.time((status) => {
+                assert.equal(status.error, false);
+                assert.equal(status.statusCode, 200);
+                done();
+            });
+        });
+    });
 
   describe('callback handling', () => {
     it('returns a correct status object', (done) => {


### PR DESCRIPTION
Added ability to configure name of SDK which should be sent along with every request as `pnsdk` query parameter.  

New configuration option which can be passed to constructor is: `sdkName`.

**Basic usage**
```js
let client = new PubNub({
    subscribeKey: 'mySubKey', 
    publishKey: 'myPublishKey', 
    uuid: 'myUUID', 
    sdkName: 'custom-sdk/1.0.0' 
});
```