### PR TITLE
categorize ETIMEDOUT errors as PNNetworkIssuesCategory

### DIFF
--- a/src/networking/index.js
+++ b/src/networking/index.js
@@ -96,6 +96,8 @@ export default class {
     if (err.status === 0 || (err.hasOwnProperty('status') && typeof err.status === 'undefined')) return categoryConstants.PNNetworkIssuesCategory;
     if (err.timeout) return categoryConstants.PNTimeoutCategory;
 
+    if (err.code === 'ETIMEDOUT') return categoryConstants.PNNetworkIssuesCategory;
+
     if (err.response) {
       if (err.response.badRequest) return categoryConstants.PNBadRequestCategory;
       if (err.response.forbidden) return categoryConstants.PNAccessDeniedCategory;


### PR DESCRIPTION
Currently the error is left uncategorized.
```
{
  "syscall": "connect",
  "errno": "ETIMEDOUT",
  "code": "ETIMEDOUT",
  "port": 443,
  "address": "54.236.3.169"
}
```
I believe this should be a `PNNetworkIssuesCategory` error.
