### PR TITLE
Replace `x || true` logic with if-else to set defaults to true.

### DIFF
--- a/lib/core/components/config.js
+++ b/lib/core/components/config.js
@@ -58,7 +58,12 @@ var _class = function () {
     this.logVerbosity = setup.logVerbosity || false;
     this.suppressLeaveEvents = setup.suppressLeaveEvents || false;
 
-    this.announceFailedHeartbeats = setup.announceFailedHeartbeats || true;
+    if (setup.announceFailedHeartbeats != null) {
+      this.announceFailedHeartbeats = setup.announceFailedHeartbeats;
+    } else {
+      this.announceFailedHeartbeats = true;
+    }
+
     this.announceSuccessfulHeartbeats = setup.announceSuccessfulHeartbeats || false;
 
     this.useInstanceId = setup.useInstanceId || false;
@@ -70,7 +75,11 @@ var _class = function () {
 
     this.setSubscribeTimeout(setup.subscribeRequestTimeout || 310 * 1000);
 
-    this.setSendBeaconConfig(setup.useSendBeacon || true);
+    if (setup.useSendBeacon != null) {
+      this.setSendBeaconConfig(setup.useSendBeacon);
+    } else {
+      this.setSendBeaconConfig(true);
+    }
 
     this.setPresenceTimeout(setup.presenceTimeout || 300);
 


### PR DESCRIPTION
In /lib/core/components/config.js, using `|| true` will always evaluate to true, thus fixing some options to always be true. 

E.g., if I set `setup.announceFailedHeartbeats = false;`, then `setup.announceFailedHeartbeats || true` will set `this.announceFailedHeartbeats` to `true` no matter what.