### PR TITLE
Do not call the reconnection callback when the polling is stopped.

### DIFF
--- a/src/core/components/reconnection_manager.js
+++ b/src/core/components/reconnection_manager.js
@@ -25,12 +25,14 @@ export default class {
 
   stopPolling() {
     clearInterval(this._timeTimer);
+    delete this._timeTimer;
   }
 
   _performTimeLoop() {
     this._timeEndpoint((status: StatusAnnouncement) => {
-      if (!status.error) {
+      if (!status.error && this._timeTimer) {
         clearInterval(this._timeTimer);
+        delete this._timeTimer;
         this._reconnectionCallback();
       }
     });


### PR DESCRIPTION
Using PubNub 4.21.6 in Node.js, sometimes the application doesn't exit after stopping PubNub. This seems to happen mostly on slow/poor networks.

After looking around, the cause is that the reconnection manager polling loop gets restarted after `pubnub.stop()` is called. 

The subscription manager correctly calls `reconnectionManager.stopPolling()`, but if at that time the reconnection manager is waiting for the response to `this._timeEndpoint()`, the reconnection callback will be called and the subscription manager will restart the polling loop.

This change makes sure the reconnection callback is used only when the polling loop is active.