### PR TITLE
Fixed Default Export

### DIFF
--- a/lib/core/components/config.js
+++ b/lib/core/components/config.js
@@ -276,4 +276,5 @@ var _default = function () {
 }();
 
 exports["default"] = _default;
+module.exports = exports["default"];
 //# sourceMappingURL=config.js.map


### PR DESCRIPTION
Fixed a backwards compatibility issue with latest patch release. After 4.24.5
```
PubNub = require('pubnub');
pn = new PubNub({...});
```
would cause error `PubNub is not a constructor`