### PR TITLE
update version number in .pubnub.yml

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -745,4 +745,4 @@ supported-platforms:
       - "Ubuntu 14.04 and above"
       - "Windows 7, 8, 10"
     version: "Pubnub Javascript for Node"
-version: "v4.26.0"
+version: "4.26.0"


### PR DESCRIPTION
Remove the leading "v" from the version number. This will un-break the download links on the JS SDK docs.