### PR TITLE
Add Message Actions API support

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,660 +1,660 @@
---- 
-changelog: 
-  - 
-    changes: 
-      - 
+---
+changelog:
+  -
+    changes:
+      -
         text: "Ensures history response is an array before iterating it"
         type: bug
     date: 2019-09-27
     version: v4.26.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Add support for auth tokens with Objects for Users, Spaces and Memberships"
         type: bug
     date: 2019-09-20
     version: v4.26.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Fix issue with subdomains ending in 'ps'"
         type: bug
     date: 2019-09-03
     version: v4.25.2
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Fix titanium build to support recent version"
         type: bug
     date: 2019-08-23
     version: v4.25.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Add Objects support for Users, Spaces and Memberships"
         type: improvement
     date: 2019-08-16
     version: v4.25.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Fix regression: 'PubNub is not a constructor' in Node.js"
         type: bug
     date: 2019-08-09
     version: v4.24.6
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Add Signals support"
         type: improvement
     date: 2019-08-07
     version: v4.24.5
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Add minimum presence timeout"
         type: improvement
     date: 2019-07-26
     version: v4.24.4
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Added support to enable heartbeat requests while subscribe when heartbeat interval is provided"
         type: improvement
     date: 2019-06-19
     version: v4.24.3
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Added try catch block to handle exception for JSON.parse function"
         type: improvement
-      - 
+      -
         text: "Updated default origin to ps.pndsn.com"
         type: improvement
     date: 2019-06-13
     version: v4.24.2
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Maintains the state when the presence heartbeat is explicitly disabled"
         type: improvement
     date: 2019-06-06
     version: v4.24.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Disables the presence heartbeat by default when a subscribe is called. Presence heartbeat can still be enabled explicitly."
         type: improvement
     date: 2019-05-09
     version: v4.24.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "The `timetoken` parameter is deprecated in the `message-counts` function. Use 'channelTimetokens' instead, pass one value in 'channelTimetokens' to achieve the same results."
         type: improvement
     date: 2019-03-14
     version: v4.23.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "message counts"
         type: feature
-      - 
+      -
         text: "use null instead of '' for NativeScript networking module"
         type: improvement
     date: 2019-03-04
     version: v4.22.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "update dependencies"
         type: improvement
-      - 
+      -
         text: "fix flow process on nativescript"
         type: improvement
     date: 2018-12-20
     version: v4.21.7
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "fix POST for nativescript adapter over android"
         type: bug
     date: 2018-10-04
     version: v4.21.6
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "update dependencies"
         type: improvement
     date: 2018-08-06
     version: v4.21.5
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "return error parameter into errorData when logVerbosity = true"
         type: improvement
     date: 2018-08-04
     version: v4.21.4
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "update dependencies"
         type: improvement
     date: 2018-07-10
     version: v4.21.3
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "add stringifiedTimeToken into the fetch endpoint"
         type: improvement
     date: 2018-06-12
     version: v4.21.2
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "avoid security vulnerability in growl < 1.10.0"
         type: bug
     date: 2018-06-08
     version: v4.21.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "subscribe without using the heartbeat loop with flag withHeartbeats = false"
         type: feature
     date: 2018-06-06
     version: v4.21.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "fix timetoken announces"
         type: bug
-      - 
+      -
         text: "categorize ETIMEDOUT errors as PNNetworkIssuesCategory"
         type: improvement
     date: 2018-04-24
     version: v4.20.3
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "fix signature to delete message"
         type: bug
     date: 2018-02-28
     version: v4.20.2
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "allow set ssl to false for nodejs"
         type: improvement
     date: 2018-01-29
     version: v4.20.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "add support for heartbeat sending without subscription via .presence()"
         type: feature
-      - 
+      -
         text: "add method setProxy for Nodejs"
         type: feature
-      - 
+      -
         text: "set ssl to true for nodejs by default"
         type: feature
     date: 2018-01-04
     version: v4.20.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "add support for Native Script"
         type: feature
-      - 
+      -
         text: "add missing flow types"
         type: improvement
-      - 
+      -
         text: "upgrade superagent to ^3.8.1"
         type: improvement
     date: 2017-12-05
     version: v4.19.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "keepAlive is now initialized globally instead of per-call, allowing better connection reuse"
         type: improvement
-      - 
+      -
         text: "added sdkName configuration parameter which allow completely override pnsdk in request query"
         type: feature
     date: 2017-11-20
     version: v4.18.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "allow disabling of heartbeats by passing 0 during initialization."
         type: improvement
     date: 2017-10-19
     version: v4.17.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "fix UUID library to work in browsers."
         type: bug
     date: 2017-10-19
     version: v4.16.2
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "fix incorrect packaging of lil-uuid and uuid"
         type: bug
     date: 2017-10-12
     version: v4.16.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "support delete messages from history"
         type: feature
-      - 
+      -
         text: "swap uuid generator with support for IE9 and IE10"
         type: improvement
     date: 2017-10-10
     version: v4.16.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "fix typo to enable http keep alive support"
         type: improvement
     date: 2017-08-21
     version: v4.15.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Support optional message deduping via the dedupeOnSubscribe config"
         type: improvement
-      - 
+      -
         text: "Do not issue leave events if the channel mix is empty."
         type: improvement
     date: 2017-08-21
     version: v4.15.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Allow disable of heartbeats by passing heartbeatInterval = 0"
         type: improvement
     date: 2017-08-14
     version: v4.14.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "patch up 503 reporting"
         type: improvement
-      - 
+      -
         text: "fix issue with where now and invalid server response"
         type: improvement
-      - 
+      -
         text: "fix issue with here now and invalid server response"
         type: improvement
     date: 2017-07-27
     version: v4.13.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "fix issue of net with android for titanium"
         type: improvement
-      - 
+      -
         text: "add additional hooks for connectivity"
         type: feature
-      - 
+      -
         text: "add auto network detection"
         type: feature
     date: 2017-06-19
     version: v4.12.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "fix issue of net with android for react-native"
         type: improvement
     date: 2017-05-23
     version: v4.10.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "metadata is now passed on message envelope"
         type: feature
     date: ~
     version: v4.9.2
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "add support custom encryption and decryption"
         type: feature
     date: 2017-05-18
     version: v4.9.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "integrate fetch for react-native SDK"
         type: feature
-      - 
+      -
         text: "announce when subscription get reactivated"
         type: improvement
-      - 
+      -
         text: "stop heartbeats for responses with status PNBadRequestCategory"
         type: improvement
     date: ~
     version: v4.9.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "allow manual control over network state via listenToBrowserNetworkEvents"
         type: feature
     date: 2017-04-06
     version: v4.8.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "add support for titanium SDK"
         type: feature
-      - 
+      -
         text: "fix support for react-native SDK"
         type: improvement
-      - 
+      -
         text: "add validation for web distribution"
         type: improvement
     date: 2017-03-30
     version: v4.7.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "add support for presence deltas."
         type: feature
-      - 
+      -
         text: "keep track of new and upcoming timetokens on status messages"
         type: feature
     date: 2017-03-27
     version: v4.6.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "add optional support for keepAlive by passing the keepAlive config into the init logic"
         type: feature
     date: 2017-03-08
     version: v4.5.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "add guard to check for channel or channel group on state setting"
         type: improvement
-      - 
+      -
         text: "add guard to check for publish, secret keys when performing a grant"
         type: improvement
     date: 2017-02-14
     version: v4.4.4
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "downgrade superagent to v2; add new entry point for react native."
         type: improvement
     date: 2017-02-07
     version: v4.4.3
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "adjust compilation for webpack based compilations"
         type: improvement
     date: 2017-01-31
     version: v4.4.2
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "proxy support for node"
         type: improvement
     date: 2017-01-31
     version: v4.4.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "upgrade dependencies; fix up linting."
         type: improvement
-      - 
+      -
         text: "handle network outage cases for correct reporting."
         type: improvement
     date: 2017-01-23
     version: v4.4.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "bump version after v3 release."
         type: improvement
     date: 2016-12-16
     version: v4.3.3
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "removes bundling of package.json into the dist file"
         type: improvement
     date: 2016-11-28
     version: v4.3.2
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "SDK now supports the restore config to allow message catch-up"
         type: improvement
     date: 2016-11-22
     version: v4.3.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "bulk history exposed via pubnub.fetchMessages"
         type: improvement
-      - 
+      -
         text: "publish supports custom ttl interval"
         type: improvement
-      - 
+      -
         text: "v2 for audit and grant; no consumer facing changes."
         type: improvement
-      - 
+      -
         text: "fixes for param validation on usage of promises"
         type: improvement
     date: 2016-11-18
     version: v4.3.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "SDK reports on the id of the publisher in the message"
         type: improvement
     date: 2016-11-04
     version: v4.2.5
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Detection of support of promises improved."
         type: improvement
     date: 2016-11-01
     version: v4.2.4
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Fixes on encoding of apostraphes."
         type: improvement
     date: 2016-11-01
     version: v4.2.3
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Add promise support on setState operation (@jskrzypek)"
         type: improvement
-      - 
+      -
         text: "Add hooks to stop polling time when the number of subscriptions drops to 0 (@jasonpoe)"
         type: improvement
     date: 2016-10-31
     version: v4.2.2
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Encode signatures to avoid sending restricted characters"
         type: improvement
     date: 2016-10-30
     version: v4.2.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Add optional support for promises on all endpoints."
         type: improvement
-      - 
+      -
         text: "History always returns timetokens in the payloads."
         type: improvement
-      - 
+      -
         text: "Optionally, if queue size is set, send status on queue size threshold"
         type: improvement
     date: 2016-10-26
     version: v4.2.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Fix state setting for channels with reserved tags."
         type: improvement
     date: 2016-10-17
     version: v4.1.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Reset timetoken when all unsubscribes happen"
         type: improvement
-      - 
+      -
         text: "Sign requests when a a secret key is passed"
         type: improvement
     date: 2016-10-13
     version: v4.1.0
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Propogate status events to the status callback on subscribe operations."
         type: improvement
     date: 2016-10-05
     version: v4.0.13
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "affectedChannels and affectedChannelGroups are now populated on subscribe / unsubscribe events"
         type: improvement
     date: 2016-10-03
     version: v4.0.12
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Dependency upgrades"
         type: improvement
     date: 2016-09-27
     version: v4.0.11
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Expose decryption and encryption as a global"
         type: improvement
     date: 2016-09-14
     version: v4.0.10
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Channel / subscription items are populated in"
         type: improvement
-      - 
+      -
         text: "Constants for operation and category are exposed on global object"
         type: improvement
     date: 2016-09-09
     version: v4.0.9
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Re-publish of v4.0.7"
         type: improvement
     date: 2016-08-25
     version: v4.0.8
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Dependency upgrades"
         type: improvement
-      - 
+      -
         text: "Try..catch wrapped around localStorage for iframe compliance"
         type: improvement
     date: 2016-08-25
     version: v4.0.7
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Adjustment of reconnection policies for web distributions."
         type: improvement
-      - 
+      -
         text: "PNSDK support for partner identification"
         type: improvement
     date: 2016-08-18
     version: v4.0.6
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Stop exposing .babelrc which causes unpredictable behavior on react native."
         type: improvement
     date: 2016-08-10
     version: v4.0.5
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Adjust handling of presence payloads for state settings."
         type: improvement
-      - 
+      -
         text: "Exposing generateUUID method to create uuids."
         type: feature
-      - 
+      -
         text: "Triggering disconnect, reconnect events on Web distributions."
         type: improvement
-      - 
+      -
         text: "React Native adjustments to package.json information."
         type: improvement
     date: 2016-08-09
     version: v4.0.4
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Global Here Now parsing adjustments."
         type: improvement
     date: 2016-08-07
     version: v4.0.3
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Adjustments to internet disconnects on node."
         type: improvement
     date: 2016-08-03
     version: v4.0.2
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "Fixes to avoid double encoding on JSON payloads."
         type: bug
     date: 2016-08-01
     version: v4.0.1
-  - 
-    changes: 
-      - 
+  -
+    changes:
+      -
         text: "New iteration of JS / Node SDK family"
         type: feature
     version: v4.0.0
-features: 
-  access: 
+features:
+  access:
     - ACCESS-GRANT
     - ACCESS-SECRET-KEY-ALL-ACCESS
     - ACCESS-GRANT-TOKEN
-  channel-groups: 
+  channel-groups:
     - CHANNEL-GROUPS-ADD-CHANNELS
     - CHANNEL-GROUPS-REMOVE-CHANNELS
     - CHANNEL-GROUPS-REMOVE-GROUPS
     - CHANNEL-GROUPS-LIST-CHANNELS-IN-GROUP
-  notify: 
+  notify:
     - REQUEST-MESSAGE-COUNT-EXCEEDED
-  presence: 
+  presence:
     - PRESENCE-HERE-NOW
     - PRESENCE-WHERE-NOW
     - PRESENCE-SET-STATE
     - PRESENCE-GET-STATE
     - PRESENCE-HEARTBEAT
-  publish: 
+  publish:
     - PUBLISH-STORE-FLAG
     - PUBLISH-RAW-JSON
     - PUBLISH-WITH-METADATA
@@ -664,12 +664,12 @@ features:
     - PUBLISH-FIRE
     - PUBLISH-REPLICATION-FLAG
     - PUBLISH-MESSAGE-TTL
-  push: 
+  push:
     - PUSH-ADD-DEVICE-TO-CHANNELS
     - PUSH-REMOVE-DEVICE-FROM-CHANNELS
     - PUSH-LIST-CHANNELS-FROM-DEVICE
     - PUSH-REMOVE-DEVICE
-  storage: 
+  storage:
     - STORAGE-REVERSE
     - STORAGE-INCLUDE-TIMETOKEN
     - STORAGE-START-END
@@ -677,7 +677,10 @@ features:
     - STORAGE-DELETE-MESSAGES
     - STORAGE-FETCH-MESSAGES
     - STORAGE-MESSAGE-COUNT
-  subscribe: 
+    - STORAGE-HISTORY-WITH-META
+    - STORAGE-FETCH-WITH-META
+    - STORAGE-FETCH-WITH-MESSAGE-ACTIONS
+  subscribe:
     - SUBSCRIBE-CHANNELS
     - SUBSCRIBE-CHANNEL-GROUPS
     - SUBSCRIBE-PRESENCE-CHANNELS
@@ -690,6 +693,7 @@ features:
     - SUBSCRIBE-USER-LISTENER
     - SUBSCRIBE-SPACE-LISTENER
     - SUBSCRIBE-MEMBERSHIP-LISTENER
+    - SUBSCRIBE-MESSAGE-ACTIONS-LISTENER
   signal:
     - SIGNAL-SEND
   objects:
@@ -711,7 +715,11 @@ features:
     - OBJECTS-ADD-MEMBERS
     - OBJECTS-UPDATE-MEMBERS
     - OBJECTS-REMOVE-MEMBERS
-  time: 
+  message-actions:
+    - MESSAGE-ACTIONS-GET
+    - MESSAGE-ACTIONS-ADD
+    - MESSAGE-ACTIONS-REMOVE
+  time:
     - TIME-TIME
   token-management:
     - TOKEN-PARSE-TOKEN
@@ -720,18 +728,18 @@ features:
     - TOKEN-GET-TOKEN
     - TOKEN-GET-TOKENS
     - TOKEN-CLEAR-TOKENS
-files: 
+files:
   - dist/web/pubnub.js
   - dist/web/pubnub.min.js
 name: javascript
 schema: 1
 scm: github.com/pubnub/javascript
-supported-platforms: 
-  - 
-    frameworks: 
+supported-platforms:
+  -
+    frameworks:
       - "Angular 1"
       - "Angular 2 using Javascript Plain"
-    platforms: 
+    platforms:
       - "Safari 10 and up"
       - "Mozilla Firefox 51 and up"
       - "Google Chrome 56 and up"
@@ -739,15 +747,15 @@ supported-platforms:
       - "IE 9 and up"
       - "Microsoft Edge 38 and up"
     version: "Pubnub Javascript for Web"
-  - 
-    editors: 
+  -
+    editors:
       - 0.12
       - 4
       - 5
       - 6
       - 7
       - 8
-    platforms: 
+    platforms:
       - "OSX 10.12 and up"
       - "Ubuntu 14.04 and above"
       - "Windows 7, 8, 10"

--- a/src/core/components/endpoint.js
+++ b/src/core/components/endpoint.js
@@ -138,7 +138,8 @@ export default function(modules, endpoint, ...args) {
   let callInstance;
   let networkingParams = { url,
     operation: endpoint.getOperation(),
-    timeout: endpoint.getRequestTimeout(modules)
+    timeout: endpoint.getRequestTimeout(modules),
+    headers: endpoint.getRequestHeaders ? endpoint.getRequestHeaders() : {}
   };
 
   outgoingParams.uuid = config.UUID;

--- a/src/core/components/listener_manager.js
+++ b/src/core/components/listener_manager.js
@@ -3,6 +3,7 @@ import {
   MessageAnnouncement,
   StatusAnnouncement,
   SignalAnnouncement,
+  MessageActionAnnouncement,
   ObjectAnnouncement,
   CallbackStruct,
   PresenceAnnouncement,
@@ -55,6 +56,12 @@ export default class {
   announceSignal(announce: SignalAnnouncement) {
     this._listeners.forEach((listener) => {
       if (listener.signal) listener.signal(announce);
+    });
+  }
+
+  announceMessageAction(announce: MessageActionAnnouncement) {
+    this._listeners.forEach((listener) => {
+      if (listener.messageAction) listener.messageAction(announce);
     });
   }
 

--- a/src/core/components/subscription_manager.js
+++ b/src/core/components/subscription_manager.js
@@ -6,6 +6,7 @@ import ReconnectionManager from '../components/reconnection_manager';
 import DedupingManager from '../components/deduping_manager';
 import utils from '../utils';
 import {
+  MessageActionAnnouncement,
   MessageAnnouncement,
   SignalAnnouncement,
   ObjectAnnouncement,
@@ -673,6 +674,25 @@ export default class {
         } else if (message.payload.type === 'membership') {
           this._listenerManager.announceMembership(announce);
         }
+      } else if (message.messageType === 3) {
+        // this is a message action
+        let announce: MessageActionAnnouncement = {};
+        announce.channel = channel;
+        announce.subscription = subscriptionMatch;
+        announce.timetoken = publishMetaData.publishTimetoken;
+        announce.publisher = message.issuingClientId;
+
+        announce.data = {
+          messageTimetoken: message.payload.data.messageTimetoken,
+          actionTimetoken: message.payload.data.actionTimetoken,
+          type: message.payload.data.type,
+          uuid: message.issuingClientId,
+          value: message.payload.data.value,
+        };
+
+        announce.event = message.payload.event;
+
+        this._listenerManager.announceMessageAction(announce);
       } else {
         let announce: MessageAnnouncement = {};
         announce.channel = null;

--- a/src/core/constants/operations.js
+++ b/src/core/constants/operations.js
@@ -13,6 +13,11 @@ export default {
   PNPublishOperation: 'PNPublishOperation',
   PNSignalOperation: 'PNSignalOperation',
 
+  // Actions API
+  PNAddMessageActionOperation: 'PNAddActionOperation',
+  PNRemoveMessageActionOperation: 'PNRemoveMessageActionOperation',
+  PNGetMessageActionsOperation: 'PNGetMessageActionsOperation',
+
   // Objects API
 
   PNCreateUserOperation: 'PNCreateUserOperation',

--- a/src/core/endpoints/actions/add_message_action.js
+++ b/src/core/endpoints/actions/add_message_action.js
@@ -1,0 +1,73 @@
+/* @flow */
+
+import {
+  AddMessageActionInput,
+  AddMessageActionResponse,
+  ModulesInject,
+} from '../../flow_interfaces';
+import operationConstants from '../../constants/operations';
+
+
+export function getOperation(): string {
+  return operationConstants.PNAddMessageActionOperation;
+}
+
+export function validateParams(
+  { config }: ModulesInject,
+  incomingParams: AddMessageActionInput
+) {
+  let { action, channel, messageTimetoken } = incomingParams;
+
+  if (!messageTimetoken) return 'Missing message timetoken';
+  if (!config.subscribeKey) return 'Missing Subscribe Key';
+  if (!channel) return 'Missing message channel';
+  if (!action) return 'Missing Action';
+  if (!action.value) return 'Missing Action.value';
+  if (!action.type) return 'Missing Action.type';
+  if (action.type.length > 15) return 'Action.type value exceed maximum length of 15';
+}
+
+export function usePost() {
+  return true;
+}
+
+export function postURL(
+  { config }: ModulesInject,
+  incomingParams: AddMessageActionInput
+): string {
+  let { channel, messageTimetoken } = incomingParams;
+
+  return `/v1/message-actions/${config.subscribeKey}/channel/${channel}/message/${messageTimetoken}`;
+}
+
+export function getRequestTimeout({ config }: ModulesInject) {
+  return config.getTransactionTimeout();
+}
+
+export function getRequestHeaders(): Object {
+  return { 'Content-Type': 'application/json' };
+}
+
+export function isAuthSupported() {
+  return true;
+}
+
+export function prepareParams(): Object {
+  return {}
+}
+
+export function postPayload(
+  modules: ModulesInject,
+  incomingParams: AddMessageActionInput
+): string {
+  let { type, value } = incomingParams.action;
+
+  return { type: type, value: value };
+}
+
+export function handleResponse(
+  modules: ModulesInject,
+  addMessageActionResponse: Object
+): AddMessageActionResponse {
+  return { data: addMessageActionResponse.data };
+}

--- a/src/core/endpoints/actions/add_message_action.js
+++ b/src/core/endpoints/actions/add_message_action.js
@@ -53,16 +53,14 @@ export function isAuthSupported() {
 }
 
 export function prepareParams(): Object {
-  return {}
+  return {};
 }
 
 export function postPayload(
   modules: ModulesInject,
   incomingParams: AddMessageActionInput
 ): string {
-  let { type, value } = incomingParams.action;
-
-  return { type: type, value: value };
+  return incomingParams.action;
 }
 
 export function handleResponse(

--- a/src/core/endpoints/actions/get_message_actions.js
+++ b/src/core/endpoints/actions/get_message_actions.js
@@ -6,7 +6,6 @@ import {
   ModulesInject,
 } from '../../flow_interfaces';
 import operationConstants from '../../constants/operations';
-import type {FetchHistoryArguments} from "../../flow_interfaces";
 
 
 export function getOperation(): string {

--- a/src/core/endpoints/actions/get_message_actions.js
+++ b/src/core/endpoints/actions/get_message_actions.js
@@ -1,0 +1,71 @@
+/* @flow */
+
+import {
+  GetMessageActionsInput,
+  GetMessageActionsResponse,
+  ModulesInject,
+} from '../../flow_interfaces';
+import operationConstants from '../../constants/operations';
+import type {FetchHistoryArguments} from "../../flow_interfaces";
+
+
+export function getOperation(): string {
+  return operationConstants.PNGetMessageActionsOperation;
+}
+
+export function validateParams(
+  { config }: ModulesInject,
+  incomingParams: GetMessageActionsInput
+) {
+  let { channel } = incomingParams;
+
+  if (!config.subscribeKey) return 'Missing Subscribe Key';
+  if (!channel) return 'Missing message channel';
+}
+
+
+export function getURL(
+  { config }: ModulesInject,
+  incomingParams: GetMessageActionsInput
+): string {
+  let { channel } = incomingParams;
+
+  return `/v1/message-actions/${config.subscribeKey}/channel/${channel}`;
+}
+
+export function getRequestTimeout({ config }: ModulesInject) {
+  return config.getTransactionTimeout();
+}
+
+export function isAuthSupported() {
+  return true;
+}
+
+export function prepareParams(
+  modules: ModulesInject,
+  incomingParams: GetMessageActionsInput
+): Object {
+  const { limit, start, end } = incomingParams;
+  let outgoingParams: Object = {};
+
+  if (limit) outgoingParams.limit = limit;
+  if (start) outgoingParams.start = start;
+  if (end) outgoingParams.end = end;
+
+  return outgoingParams;
+}
+
+export function handleResponse(
+  modules: ModulesInject,
+  getMessageActionsResponse: Object
+): GetMessageActionsResponse {
+  /** @type GetMessageActionsResponse */
+  let response = { data: getMessageActionsResponse.data };
+
+  if (response.data.length) {
+    response.end = response.data[response.data.length - 1].actionTimetoken;
+    response.start = response.data[0].actionTimetoken;
+  }
+
+  return response;
+}

--- a/src/core/endpoints/actions/remove_message_action.js
+++ b/src/core/endpoints/actions/remove_message_action.js
@@ -1,0 +1,57 @@
+/* @flow */
+
+import {
+  RemoveMessageActionInput,
+  RemoveMessageActionResponse,
+  ModulesInject,
+} from '../../flow_interfaces';
+import operationConstants from '../../constants/operations';
+
+
+export function getOperation(): string {
+  return operationConstants.PNRemoveMessageActionOperation;
+}
+
+export function validateParams(
+  { config }: ModulesInject,
+  incomingParams: RemoveMessageActionInput
+) {
+  let { channel, actionTimetoken, messageTimetoken } = incomingParams;
+
+  if (!messageTimetoken) return 'Missing message timetoken';
+  if (!actionTimetoken) return 'Missing action timetoken';
+  if (!config.subscribeKey) return 'Missing Subscribe Key';
+  if (!channel) return 'Missing message channel';
+}
+
+export function useDelete() {
+  return true;
+}
+
+export function getURL(
+  { config }: ModulesInject,
+  incomingParams: RemoveMessageActionInput
+): string {
+  let { channel, actionTimetoken, messageTimetoken } = incomingParams;
+
+  return `/v1/message-actions/${config.subscribeKey}/channel/${channel}/message/${messageTimetoken}/action/${actionTimetoken}`;
+}
+
+export function getRequestTimeout({ config }: ModulesInject) {
+  return config.getTransactionTimeout();
+}
+
+export function isAuthSupported() {
+  return true;
+}
+
+export function prepareParams(): Object {
+  return {}
+}
+
+export function handleResponse(
+  modules: ModulesInject,
+  removeMessageActionResponse: Object
+): RemoveMessageActionResponse {
+  return { data: removeMessageActionResponse.data };
+}

--- a/src/core/endpoints/actions/remove_message_action.js
+++ b/src/core/endpoints/actions/remove_message_action.js
@@ -46,7 +46,7 @@ export function isAuthSupported() {
 }
 
 export function prepareParams(): Object {
-  return {}
+  return {};
 }
 
 export function handleResponse(

--- a/src/core/endpoints/history/get_history.js
+++ b/src/core/endpoints/history/get_history.js
@@ -64,6 +64,7 @@ export function prepareParams(
     reverse,
     count = 100,
     stringifiedTimeToken = false,
+    includeMeta = false,
   } = incomingParams;
   let outgoingParams: Object = {
     include_token: 'true',
@@ -74,6 +75,7 @@ export function prepareParams(
   if (end) outgoingParams.end = end;
   if (stringifiedTimeToken) outgoingParams.string_message_token = 'true';
   if (reverse != null) outgoingParams.reverse = reverse.toString();
+  if (includeMeta) outgoingParams.include_meta = 'true';
 
   return outgoingParams;
 }
@@ -94,6 +96,10 @@ export function handleResponse(
         timetoken: serverHistoryItem.timetoken,
         entry: __processMessage(modules, serverHistoryItem.message),
       };
+
+      if (serverHistoryItem.meta) {
+        item.meta = serverHistoryItem.meta;
+      }
 
       response.messages.push(item);
     });

--- a/src/core/flow_interfaces.js
+++ b/src/core/flow_interfaces.js
@@ -10,7 +10,12 @@ declare module 'superagent' {
 export type CallbackStruct = {
   status: Function,
   presence: Function,
-  message: Function
+  message: Function,
+  signal: Function,
+  messageAction: Function,
+  user: Function,
+  space: Function,
+  membership: Function
 }
 
 export type ProxyStruct = {
@@ -77,8 +82,9 @@ type SupportedParams = {
   uuid: EndpointKeyDefinition,
 }
 
-export type endpointDefinition = {
+export type EndpointDefinition = {
   params: SupportedParams,
+  headers?: Object,
   timeout: number,
   url: string
 }
@@ -171,6 +177,18 @@ type SignalAnnouncement = {
   publisher: string
 }
 
+type MessageActionAnnouncement = {
+  data: PublishedMessageAction,
+  event: string,
+
+  channel: string,
+  subscription: string,
+
+  timetoken: number | string,
+  userMetadata: Object,
+  publisher: string
+}
+
 type ObjectMessage = {
   event: string,
   type: string,
@@ -216,6 +234,7 @@ type FetchHistoryArguments = {
   start: number | string, // start timetoken for history fetching
   end: number | string, // end timetoken for history fetching
   includeTimetoken: boolean, // include time token for each history call
+  includeMeta: boolean, // include message meta for each history entry
   reverse: boolean,
   count: number
 }
@@ -231,11 +250,14 @@ type FetchMessagesArguments = {
   channels: string, // fetch history from a channel
   start: number | string, // start timetoken for history fetching
   end: number | string, // end timetoken for history fetching
+  includeMeta: boolean, // include message meta for each history entry
+  includeMessageActions: boolean, // include message actions for each history entry
   count: number
 }
 
 type HistoryItem = {
   timetoken: number | string | null,
+  meta: Object | null,
   entry: any,
 }
 
@@ -492,6 +514,52 @@ type SignalResponse = {
 type SignalArguments = {
   message: Object | string | number | boolean,
   channel: string
+}
+
+// Actions
+
+interface MessageAction {
+  type: string,
+  value: string,
+}
+
+interface PublishedMessageAction extends MessageAction {
+  messageTimetoken: string,
+  actionTimetoken: string,
+  uuid: string,
+}
+
+interface AddMessageActionInput {
+  messageTimetoken: string,
+  channel: string,
+  action: MessageAction,
+}
+
+interface AddMessageActionResponse {
+  data: PublishedMessageAction,
+}
+
+interface RemoveMessageActionInput {
+  messageTimetoken: string,
+  actionTimetoken: string,
+  channel: string,
+}
+
+interface RemoveMessageActionResponse {
+  data: {},
+}
+
+interface GetMessageActionsInput {
+  channel: string,
+  start?: number | string,
+  end?: number | string,
+  limit?: number,
+}
+
+interface GetMessageActionsResponse {
+  data: Array<PublishedMessageAction>,
+  start?: string,
+  end?: string,
 }
 
 // Users Object

--- a/src/core/flow_interfaces.js
+++ b/src/core/flow_interfaces.js
@@ -177,18 +177,6 @@ type SignalAnnouncement = {
   publisher: string
 }
 
-type MessageActionAnnouncement = {
-  data: PublishedMessageAction,
-  event: string,
-
-  channel: string,
-  subscription: string,
-
-  timetoken: number | string,
-  userMetadata: Object,
-  publisher: string
-}
-
 type ObjectMessage = {
   event: string,
   type: string,
@@ -527,6 +515,18 @@ interface PublishedMessageAction extends MessageAction {
   messageTimetoken: string,
   actionTimetoken: string,
   uuid: string,
+}
+
+type MessageActionAnnouncement = {
+  data: PublishedMessageAction,
+  event: string,
+
+  channel: string,
+  subscription: string,
+
+  timetoken: number | string,
+  userMetadata: Object,
+  publisher: string
 }
 
 interface AddMessageActionInput {

--- a/src/core/pubnub-common.js
+++ b/src/core/pubnub-common.js
@@ -26,6 +26,12 @@ import * as presenceGetStateConfig from './endpoints/presence/get_state';
 import * as presenceSetStateConfig from './endpoints/presence/set_state';
 import * as presenceHereNowConfig from './endpoints/presence/here_now';
 
+// Actions API
+
+import * as addMessageActionEndpointConfig from './endpoints/actions/add_message_action';
+import * as removeMessageActionEndpointConfig from './endpoints/actions/remove_message_action';
+import * as getMessageActionEndpointConfig from './endpoints/actions/get_message_actions';
+
 // Objects API
 
 import * as createUserEndpointConfig from './endpoints/users/create_user';
@@ -100,6 +106,11 @@ export default class {
   presence: Function;
   unsubscribe: Function;
   unsubscribeAll: Function;
+
+  // Actions API
+  addMessageAction: Function;
+  removeMessageAction: Function;
+  getMessageActions: Function;
 
   // Objects API
 
@@ -302,6 +313,26 @@ export default class {
       this,
       modules,
       fetchMessagesEndpointConfig
+    );
+
+    // Actions API
+
+    this.addMessageAction = endpointCreator.bind(
+      this,
+      modules,
+      addMessageActionEndpointConfig
+    );
+
+    this.removeMessageAction = endpointCreator.bind(
+      this,
+      modules,
+      removeMessageActionEndpointConfig
+    );
+
+    this.getMessageActions = endpointCreator.bind(
+      this,
+      modules,
+      getMessageActionEndpointConfig
     );
 
     // Objects API

--- a/src/nativescript/index.js
+++ b/src/nativescript/index.js
@@ -3,13 +3,13 @@
 import PubNubCore from '../core/pubnub-common';
 import Networking from '../networking';
 import Database from '../db/common';
-import { del, get, post } from '../networking/modules/nativescript';
+import { del, get, post, patch } from '../networking/modules/nativescript';
 import { InternalSetupStruct } from '../core/flow_interfaces';
 
 export default class extends PubNubCore {
   constructor(setup: InternalSetupStruct) {
     setup.db = new Database();
-    setup.networking = new Networking({ del, get, post });
+    setup.networking = new Networking({ del, get, post, patch });
     setup.sdkFamily = 'NativeScript';
     super(setup);
   }

--- a/src/networking/modules/web-node.js
+++ b/src/networking/modules/web-node.js
@@ -101,6 +101,8 @@ function xdr(
       status.error = true;
       status.category = this._detectErrorCategory(status);
       return callback(status, null);
+    } else if (parsedResponse.error && parsedResponse.error.message) {
+      status.errorData = parsedResponse.error;
     }
 
     return callback(status, parsedResponse);
@@ -114,6 +116,7 @@ export function get(
 ): superagent {
   let superagentConstruct = superagent
     .get(this.getStandardOrigin() + endpoint.url)
+    .set(endpoint.headers)
     .query(params);
   return xdr.call(this, superagentConstruct, endpoint, callback);
 }
@@ -127,6 +130,7 @@ export function post(
   let superagentConstruct = superagent
     .post(this.getStandardOrigin() + endpoint.url)
     .query(params)
+    .set(endpoint.headers)
     .send(body);
   return xdr.call(this, superagentConstruct, endpoint, callback);
 }
@@ -140,6 +144,7 @@ export function patch(
   let superagentConstruct = superagent
     .patch(this.getStandardOrigin() + endpoint.url)
     .query(params)
+    .set(endpoint.headers)
     .send(body);
   return xdr.call(this, superagentConstruct, endpoint, callback);
 }
@@ -151,6 +156,7 @@ export function del(
 ): superagent {
   let superagentConstruct = superagent
     .delete(this.getStandardOrigin() + endpoint.url)
+    .set(endpoint.headers)
     .query(params);
   return xdr.call(this, superagentConstruct, endpoint, callback);
 }

--- a/test/integration/endpoints/fetch_messages.test.js
+++ b/test/integration/endpoints/fetch_messages.test.js
@@ -1,4 +1,4 @@
-/* global describe, beforeEach, it, before, after */
+/* global describe, beforeEach, afterEach, it, before, after */
 /* eslint no-console: 0 */
 
 import assert from 'assert';
@@ -6,30 +6,118 @@ import nock from 'nock';
 import utils from '../../utils';
 import PubNub from '../../../src/node/index';
 
-describe('fetch messages endpoints', () => {
-  let pubnub;
+function publishMessagesToChannel(client: PubNub, count: Number, channel: String, completion: Function) {
+  let publishCompleted = 0;
+  let messages = [];
 
-  before(() => {
-    nock.disableNetConnect();
-  });
+  const publish = (messageIdx) => {
+    let payload = { message: { messageIdx: [channel, messageIdx].join(': '), time: Date.now() }, channel };
+
+    if (messageIdx % 2 === 0) {
+      payload.meta = { time: payload.message.time };
+    }
+
+    client.publish(payload, (status, response) => {
+      publishCompleted++;
+
+      if (!status.error) {
+        messages.push({ message: payload.message, timetoken: response.timetoken });
+        messages = messages.sort((left, right) => left.timetoken - right.timetoken);
+      } else {
+        console.error('Publish did fail:', status);
+      }
+
+        if (publishCompleted < count) {
+          publish(publishCompleted);
+        } else if (publishCompleted === count) {
+          completion(messages);
+        }
+      }
+    );
+  };
+
+  publish(publishCompleted);
+}
+
+function addActionsInChannel(client: PubNub, count: Number, messageTimetokens: Array<Number>, channel: String, completion: Function) {
+  const types = ['reaction', 'receipt', 'custom'];
+  const values = [
+    PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID(),
+    PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID()
+  ];
+  let actionsToAdd = [];
+  let actionsAdded = 0;
+  let actions = [];
+
+  for (let messageIdx = 0; messageIdx < messageTimetokens.length; messageIdx++) {
+    const messageTimetoken = messageTimetokens[messageIdx];
+
+    for (let messageActionIdx = 0; messageActionIdx < count; messageActionIdx++) {
+      /** @type MessageAction */
+      const action = { type: types[(messageActionIdx + 1)%3], value: values[(messageActionIdx + 1)%10] };
+
+      actionsToAdd.push({ messageTimetoken, action });
+    }
+  }
+
+  const addAction = (actionIdx) => {
+    const { messageTimetoken, action } = actionsToAdd[actionIdx];
+
+    client.addMessageAction(
+      { channel, messageTimetoken, action },
+      (status, response) => {
+        actionsAdded++;
+
+        if (!status.error) {
+          actions.push(response.data);
+          actions = actions.sort((left, right) => left.actionTimetoken - right.actionTimetoken);
+        } else {
+          console.error('Action add did fail:', status);
+        }
+
+        if (actionsAdded < actionsToAdd.length) {
+          addAction(actionsAdded);
+        } else if (actionsAdded === actionsToAdd.length) {
+          completion(actions);
+        }
+      }
+    );
+  };
+
+  addAction(actionsAdded);
+}
+
+
+describe('fetch messages endpoints', () => {
+  const subscribeKey = process.env.SUBSCRIBE_KEY || 'demo';
+  const publishKey = process.env.PUBLISH_KEY || 'demo';
+  let pubnub;
 
   after(() => {
     nock.enableNetConnect();
   });
 
+  afterEach(() => {
+    nock.enableNetConnect();
+    pubnub.removeAllListeners();
+    pubnub.unsubscribeAll();
+    pubnub.stop();
+  });
+
   beforeEach(() => {
     nock.cleanAll();
     pubnub = new PubNub({
-      subscribeKey: 'mySubKey',
-      publishKey: 'myPublishKey',
+      subscribeKey: subscribeKey,
+      publishKey: publishKey,
       uuid: 'myUUID',
     });
   });
 
   it('supports payload', (done) => {
+    nock.disableNetConnect();
     const scope = utils
       .createNock()
-      .get('/v3/history/sub-key/mySubKey/channel/ch1%2Cch2')
+      .get(`/v3/history/sub-key/${subscribeKey}/channel/ch1%2Cch2`)
       .query({
         max: '10',
         pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
@@ -91,9 +179,10 @@ describe('fetch messages endpoints', () => {
   });
 
   it('supports encrypted payload', (done) => {
+    nock.disableNetConnect();
     const scope = utils
       .createNock()
-      .get('/v3/history/sub-key/mySubKey/channel/ch1%2Cch2')
+      .get(`/v3/history/sub-key/${subscribeKey}/channel/ch1%2Cch2`)
       .query({
         max: '10',
         pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
@@ -154,4 +243,78 @@ describe('fetch messages endpoints', () => {
       }
     );
   });
+
+  it('supports metadata', (done) => {
+    const channel = PubNub.generateUUID();
+    const expectedMessagesCount = 10;
+
+    publishMessagesToChannel(pubnub, expectedMessagesCount, channel, (messages) => {
+      pubnub.fetchMessages({ channels: [channel], count: 25, includeMeta: true }, (status, response) => {
+        const channelMessages = response.channels[channel];
+
+        assert.deepEqual(channelMessages[0].meta, { time: messages[0].message.time });
+        assert(!channelMessages[1].meta);
+        done();
+      });
+    });
+  }).timeout(60000);
+
+  it('throws when requested actions for multiple channels', () => {
+    let errorCatched = false;
+
+    try {
+      pubnub.fetchMessages(
+        { channels: ['channelA', 'channelB'], includeMessageActions: true },
+        (status, response) => {}
+      );
+    } catch (error) {
+      assert.equal(error.message, 'History can return actions data for a single channel only. Either pass a single channel or disable the includeMessageActions flag.');
+      errorCatched = true;
+    }
+
+    assert(errorCatched);
+  });
+
+  it('supports actions', (done) => {
+    const channel = PubNub.generateUUID();
+    const expectedMessagesCount = 2;
+    const expectedActionsCount = 4;
+
+    publishMessagesToChannel(pubnub, expectedMessagesCount, channel, (messages) => {
+      const messageTimetokens = messages.map((message) => message.timetoken );
+
+      addActionsInChannel(pubnub, expectedActionsCount, messageTimetokens, channel, (actions) => {
+        setTimeout(() => {
+          pubnub.fetchMessages({ channels: [channel], includeMessageActions: true }, (status, response) => {
+            assert.equal(status.error, false);
+            const fetchedMessages = response.channels[channel];
+            const actionsByType = fetchedMessages[0].data;
+            let historyActionsCount = 0;
+
+            Object.keys(actionsByType).forEach((actionType) => {
+              Object.keys(actionsByType[actionType]).forEach((actionValue) => {
+                let actionFound = false;
+                historyActionsCount++;
+
+                actions.forEach((action) => {
+                  if (action.value === actionValue) {
+                    actionFound = true;
+                  }
+                });
+
+                assert.equal(actionFound, true);
+              });
+            });
+
+            assert.equal(historyActionsCount, expectedActionsCount);
+            assert.equal(fetchedMessages[0].timetoken, messageTimetokens[0]);
+            assert.equal(fetchedMessages[fetchedMessages.length - 1].timetoken,
+                         messageTimetokens[messageTimetokens.length - 1]);
+
+            done();
+          });
+        }, 2000);
+      });
+    });
+  }).timeout(60000);
 });

--- a/test/integration/endpoints/grant_token.test.js
+++ b/test/integration/endpoints/grant_token.test.js
@@ -261,8 +261,8 @@ describe('grant token endpoint', () => {
           }
         },
         (status) => {
-          assert.equal(status.error, false);
           assert.equal(scope.isDone(), true);
+          assert.equal(status.error, false);
           done();
         }
       );

--- a/test/integration/endpoints/message_actions.test.js
+++ b/test/integration/endpoints/message_actions.test.js
@@ -108,9 +108,6 @@ describe('message actions endpoints', () => {
       publishKey: publishKey,
       uuid: 'myUUID',
       authKey: 'myAuthKey',
-      // ssl: false,
-      // origin: 'ingress.bronze.aws-pdx-1.ps.pn',
-      // logVerbosity: true,
     });
   });
 

--- a/test/integration/endpoints/message_actions.test.js
+++ b/test/integration/endpoints/message_actions.test.js
@@ -1,0 +1,537 @@
+/* global describe, beforeEach, afterEach, it, before, after, jasmine */
+/* eslint no-console: 0 */
+
+import PubNub from '../../../src/node/index';
+import utils from "../../utils";
+import assert from 'assert';
+import nock from 'nock';
+
+
+function publishMessages(client: PubNub, count: Number, channel: String, completion: Function) {
+  let publishCompleted = 0;
+  let timetokens = [];
+
+  const publish = (messageIdx) => {
+    const message = { messageIdx, time: Date.now() };
+
+    client.publish(
+      { message, channel },
+      (status, response) => {
+        publishCompleted++;
+
+        if (!status.error) {
+          timetokens.push(response.timetoken);
+        } else {
+          console.error('Publish did fail:', status);
+        }
+
+        if (publishCompleted < count) {
+          publish(publishCompleted);
+        } else if (publishCompleted === count) {
+          completion(timetokens.sort((left, right) => left - right));
+        }
+      }
+    );
+  };
+
+  publish(publishCompleted);
+}
+
+function addActions(client: PubNub, count: Number, messageTimetokens: Array<Number>, channel: String, completion: Function) {
+  const types = ['reaction', 'receipt', 'custom'];
+  const values = [
+    PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID(),
+    PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID(), PubNub.generateUUID()
+  ];
+  let actionsToAdd = [];
+  let actionsAdded = 0;
+  let timetokens = [];
+
+  for (let messageIdx = 0; messageIdx < messageTimetokens.length; messageIdx++) {
+    const messageTimetoken = messageTimetokens[messageIdx];
+
+    for (let messageActionIdx = 0; messageActionIdx < count; messageActionIdx++) {
+      /** @type MessageAction */
+      const action = { type: types[(messageActionIdx + 1) % 3], value: values[(messageActionIdx + 1) % 10] };
+
+      actionsToAdd.push({ messageTimetoken, action });
+    }
+  }
+
+  const addAction = (actionIdx) => {
+    const { messageTimetoken, action } = actionsToAdd[actionIdx];
+
+    client.addMessageAction(
+      { channel, messageTimetoken, action },
+      (status, response) => {
+        actionsAdded++;
+
+        if (!status.error) {
+          timetokens.push(response.data.actionTimetoken);
+        } else {
+          console.error('Action add did fail:', action, '\n', status);
+        }
+
+        if (actionsAdded < actionsToAdd.length) {
+          addAction(actionsAdded);
+        } else if (actionsAdded === actionsToAdd.length) {
+          completion(timetokens.sort((left, right) => left - right));
+        }
+      }
+    );
+  };
+
+  addAction(actionsAdded);
+}
+
+
+describe('message actions endpoints', () => {
+  const subscribeKey = process.env.SUBSCRIBE_KEY || 'demo';
+  const publishKey = process.env.PUBLISH_KEY || 'demo';
+  let pubnub;
+
+  after(() => {
+    nock.enableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.enableNetConnect();
+    pubnub.removeAllListeners();
+    pubnub.unsubscribeAll();
+    pubnub.stop();
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+    pubnub = new PubNub({
+      subscribeKey: subscribeKey,
+      publishKey: publishKey,
+      uuid: 'myUUID',
+      authKey: 'myAuthKey',
+      // ssl: false,
+      // origin: 'ingress.bronze.aws-pdx-1.ps.pn',
+      // logVerbosity: true,
+    });
+  });
+
+  describe('addMessageAction', () => {
+    describe('##validation', () => {
+      it('fails if \'action\' is missing', (done) => {
+        nock.disableNetConnect();
+        const scope = utils
+          .createNock()
+            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
+            .reply(200, {});
+
+        pubnub.addMessageAction({
+            channel: 'test-channel',
+            messageTimetoken: '1234567890',
+          })
+          .catch((err) => {
+            assert.equal(scope.isDone(), false);
+            assert.equal(err.status.message, 'Missing Action');
+            done();
+          });
+      });
+
+      it('fails if \'type\' is missing', (done) => {
+        nock.disableNetConnect();
+        const scope = utils
+          .createNock()
+            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
+            .reply(200, {});
+        const action = { value: 'test value' };
+
+        pubnub.addMessageAction({
+            channel: 'test-channel',
+            messageTimetoken: '1234567890',
+            action,
+          })
+          .catch((err) => {
+            assert.equal(scope.isDone(), false);
+            assert.equal(err.status.message, 'Missing Action.type');
+            done();
+          });
+      });
+
+      it('fails if \'type\' is too long', (done) => {
+        nock.disableNetConnect();
+        const scope = utils
+          .createNock()
+            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
+            .reply(200, {});
+        const action = { type: PubNub.generateUUID(), value: 'test value' };
+
+        pubnub.addMessageAction({
+            channel: 'test-channel',
+            messageTimetoken: '1234567890',
+            action,
+          })
+          .catch((err) => {
+            assert.equal(scope.isDone(), false);
+            assert.equal(err.status.message, 'Action.type value exceed maximum length of 15');
+            done();
+          });
+      });
+
+      it('fails if \'value\' is missing', (done) => {
+        nock.disableNetConnect();
+        const scope = utils
+          .createNock()
+            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
+            .reply(200, {});
+        const action = { type: 'custom' };
+
+        pubnub.addMessageAction({
+            channel: 'test-channel',
+            messageTimetoken: '1234567890',
+            action,
+          })
+          .catch((err) => {
+            assert.equal(scope.isDone(), false);
+            assert.equal(err.status.message, 'Missing Action.value');
+            done();
+          });
+      });
+
+      it('fails if \'messageTimetoken\' is missing', (done) => {
+        nock.disableNetConnect();
+        const scope = utils
+          .createNock()
+            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/`)
+            .reply(200, {});
+        const action = { type: 'custom', value: 'test value' };
+
+        pubnub.addMessageAction({
+            channel: 'test-channel',
+            action,
+          })
+          .catch((err) => {
+            assert.equal(scope.isDone(), false);
+            assert.equal(err.status.message, 'Missing message timetoken');
+            done();
+          });
+      });
+
+      it('fails if \'channel\' is missing', (done) => {
+        nock.disableNetConnect();
+        const scope = utils
+          .createNock()
+            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
+            .reply(200, {});
+        const action = { type: 'custom', value: 'test value' };
+
+        pubnub.addMessageAction({
+            messageTimetoken: '1234567890',
+            action,
+          })
+          .catch((err) => {
+            assert.equal(scope.isDone(), false);
+            assert.equal(err.status.message, 'Missing message channel');
+            done();
+          });
+      });
+    });
+
+    it('add message action', (done) => {
+      /** @type MessageAction */
+      const messageAction = { type: 'custom', value: PubNub.generateUUID() };
+      const channel = PubNub.generateUUID();
+
+      publishMessages(pubnub,1, channel, (timetokens) => {
+        pubnub.addMessageAction(
+          { channel: channel, messageTimetoken: timetokens[0], action: messageAction },
+          (status, response) => {
+            assert.equal(status.error, false);
+            assert.equal(response.data.type, messageAction.type);
+            assert.equal(response.data.value, messageAction.value);
+            assert.equal(response.data.uuid, pubnub.getUUID());
+            assert.equal(response.data.messageTimetoken, timetokens[0]);
+            assert(response.data.actionTimetoken);
+
+            done();
+          }
+        );
+      });
+    }).timeout(60000);
+
+    it('add message action and 207 status code', (done) => {
+      nock.disableNetConnect();
+      const scope = utils
+        .createNock()
+        .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
+        .query({
+          pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
+          uuid: 'myUUID',
+          auth: 'myAuthKey'
+        })
+        .reply(207, {
+          "status": 207,
+          "data": {
+            "type": "reaction",
+            "value": "smiley_face",
+            "uuid": "user-456",
+            "actionTimetoken": '15610547826970050',
+            "messageTimetoken": '15610547826969050'
+          },
+          "error": {
+            "message": "Stored but failed to publish message action.",
+            "source": "actions"
+          }
+        });
+
+      pubnub.addMessageAction(
+        { channel: 'test-channel', messageTimetoken: '1234567890', action: { type: 'custom', value: 'test' } },
+         (status, response) => {
+          assert.equal(scope.isDone(), true);
+          assert.equal(status.statusCode, 207);
+          assert(status.errorData.message);
+
+          done();
+        }
+      );
+    });
+
+    it('add message action should trigger event', (done) => {
+      /** @type MessageAction */
+      const messageAction = { type: 'custom', value: PubNub.generateUUID() };
+      const channel = PubNub.generateUUID();
+      let messageTimetoken = null;
+
+      pubnub.addListener({
+        status: (status) => {
+          if (status.category === 'PNConnectedCategory') {
+            pubnub.publish(
+              { channel, message: { hello: 'test' }, sendByPost: true },
+              (status, response) => {
+                messageTimetoken = response.timetoken;
+
+                pubnub.addMessageAction(
+                  { channel, messageTimetoken, action: messageAction }
+                );
+              }
+            );
+          }
+        },
+        messageAction: (messageActionEvent) => {
+          assert(messageActionEvent.data);
+          assert.equal(messageActionEvent.data.type, messageAction.type);
+          assert.equal(messageActionEvent.data.value, messageAction.value);
+          assert.equal(messageActionEvent.data.uuid, pubnub.getUUID());
+          assert.equal(messageActionEvent.data.messageTimetoken, messageTimetoken);
+          assert(messageActionEvent.data.actionTimetoken);
+          assert.equal(messageActionEvent.event, 'added');
+
+          done();
+        }
+      });
+
+      pubnub.subscribe({ channels: [channel] });
+    }).timeout(60000);
+  });
+
+  describe('removeMessageAction', () => {
+    describe('##validation', () => {
+      it('fails if \'messageTimetoken\' is missing', (done) => {
+        nock.disableNetConnect();
+        const scope = utils
+          .createNock()
+          .delete(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890/action/12345678901`)
+          .reply(200, {});
+
+        pubnub.removeMessageAction({
+            channel: 'test-channel',
+            actionTimetoken: '1234567890',
+          })
+          .catch((err) => {
+            assert.equal(scope.isDone(), false);
+            assert.equal(err.status.message, 'Missing message timetoken');
+
+            done();
+          });
+      });
+
+      it('fails if \'actionTimetoken\' is missing', (done) => {
+        nock.disableNetConnect();
+        const scope = utils
+          .createNock()
+          .delete(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890/action/12345678901`)
+          .reply(200, {});
+
+        pubnub.removeMessageAction({
+            channel: 'test-channel',
+            messageTimetoken: '1234567890',
+          })
+          .catch((err) => {
+            assert.equal(scope.isDone(), false);
+            assert.equal(err.status.message, 'Missing action timetoken');
+
+            done();
+          });
+      });
+
+      it('fails if \'channel\' is missing', (done) => {
+        nock.disableNetConnect();
+        const scope = utils
+          .createNock()
+          .delete(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890/action/12345678901`)
+          .reply(200, {});
+
+        pubnub.removeMessageAction({
+            messageTimetoken: '1234567890',
+            actionTimetoken: '12345678901',
+          })
+          .catch((err) => {
+            assert.equal(scope.isDone(), false);
+            assert.equal(err.status.message, 'Missing message channel');
+
+            done();
+          });
+      });
+    });
+
+    it('remove message action', (done) => {
+      const channel = PubNub.generateUUID();
+
+      publishMessages(pubnub, 1, channel, (messageTimetokens) => {
+        addActions(pubnub, 1, messageTimetokens, channel, (actionTimetokens) => {
+          pubnub.getMessageActions({ channel }, (status, response) => {
+            assert.equal(status.error, false);
+            assert.equal(response.data.length, actionTimetokens.length);
+
+            pubnub.removeMessageAction(
+              { channel, actionTimetoken: actionTimetokens[0], messageTimetoken: messageTimetokens[0] },
+              (status) => {
+                assert.equal(status.error, false);
+
+                setTimeout(() => {
+                  pubnub.getMessageActions({ channel }, (status, response) => {
+                    assert.equal(status.error, false);
+                    assert.equal(response.data.length, 0);
+
+                    done();
+                  });
+                }, 2000);
+              }
+            );
+          });
+        });
+      });
+    }).timeout(60000);
+
+    it('remove message action should trigger event', (done) => {
+      const channel = PubNub.generateUUID();
+
+      publishMessages(pubnub, 1, channel, (messageTimetokens) => {
+        addActions(pubnub, 1, messageTimetokens, channel, (actionTimetokens) => {
+          pubnub.addListener({
+            status: (status) => {
+              if (status.category === 'PNConnectedCategory') {
+                pubnub.removeMessageAction(
+                  {channel, actionTimetoken: actionTimetokens[0], messageTimetoken: messageTimetokens[0]},
+                  (status) => {
+                    assert.equal(status.error, false);
+                  }
+                );
+              }
+            },
+            messageAction: (messageActionEvent) => {
+              assert(messageActionEvent.data);
+              assert.equal(messageActionEvent.data.uuid, pubnub.getUUID());
+              assert.equal(messageActionEvent.data.messageTimetoken, messageTimetokens[0]);
+              assert.equal(messageActionEvent.data.actionTimetoken, actionTimetokens[0]);
+              assert.equal(messageActionEvent.event, 'removed');
+
+              done();
+            }
+          });
+
+          pubnub.subscribe({ channels: [channel] });
+        });
+      });
+    }).timeout(60000);
+  });
+
+  describe('getMessageAction', () => {
+    describe('##validation', () => {
+      it('fails if \'channel\' is missing', (done) => {
+        nock.disableNetConnect();
+        const scope = utils
+          .createNock()
+          .get(`/v1/message-actions/${subscribeKey}/channel/test-channel`)
+          .reply(200, {});
+
+        pubnub.getMessageActions({}).catch((err) => {
+          assert.equal(scope.isDone(), false);
+          assert.equal(err.status.message, 'Missing message channel');
+
+          done();
+        });
+      });
+    });
+
+    it('fetch message actions', (done) => {
+      const channel = PubNub.generateUUID();
+
+      publishMessages(pubnub, 2, channel, (messageTimetokens) => {
+        addActions(pubnub, 3, messageTimetokens, channel, (actionTimetokens) => {
+          const lastPublishedActionTimetoken = actionTimetokens[actionTimetokens.length - 1];
+          const firstPublishedActionTimetoken = actionTimetokens[0];
+
+          pubnub.getMessageActions({ channel }, (status, response) => {
+            assert.equal(status.error, false);
+            const firstFetchedActionTimetoken = response.data[0].actionTimetoken;
+            const lastFetchedActionTimetoken = response.data[response.data.length - 1].actionTimetoken;
+            assert.equal(firstFetchedActionTimetoken, firstPublishedActionTimetoken);
+            assert.equal(lastFetchedActionTimetoken, lastPublishedActionTimetoken);
+            assert.equal(response.data.length, actionTimetokens.length);
+            assert.equal(response.start, firstPublishedActionTimetoken);
+            assert.equal(response.end, lastPublishedActionTimetoken);
+
+            done();
+          });
+        });
+      });
+    }).timeout(60000);
+
+    it('fetch next message actions page', (done) => {
+      const channel = PubNub.generateUUID();
+
+      publishMessages(pubnub, 2, channel, (messageTimetokens) => {
+        addActions(pubnub, 5, messageTimetokens, channel, (actionTimetokens) => {
+          const lastPublishedActionTimetoken = actionTimetokens[actionTimetokens.length - 1];
+          const halfSize = Math.floor(actionTimetokens.length * 0.5);
+          const firstPublishedActionTimetoken = actionTimetokens[0];
+          const middleMinusOnePublishedActionTimetoken = actionTimetokens[halfSize - 1];
+          const middlePublishedActionTimetoken = actionTimetokens[halfSize];
+
+          pubnub.getMessageActions({ channel, limit: halfSize }, (status, response) => {
+            assert.equal(status.error, false);
+            const firstFetchedActionTimetoken = response.data[0].actionTimetoken;
+            const lastFetchedActionTimetoken = response.data[response.data.length - 1].actionTimetoken;
+            assert.equal(firstFetchedActionTimetoken, middlePublishedActionTimetoken);
+            assert.equal(lastFetchedActionTimetoken, lastPublishedActionTimetoken);
+            assert.equal(response.data.length, halfSize);
+            assert.equal(response.start, middlePublishedActionTimetoken);
+            assert.equal(response.end, lastPublishedActionTimetoken);
+
+            pubnub.getMessageActions(
+              { channel, start: middlePublishedActionTimetoken, limit: halfSize },
+              (status, response) => {
+                assert.equal(status.error, false);
+                const firstFetchedActionTimetoken = response.data[0].actionTimetoken;
+                const lastFetchedActionTimetoken = response.data[response.data.length - 1].actionTimetoken;
+                assert.equal(firstFetchedActionTimetoken, firstPublishedActionTimetoken);
+                assert.equal(lastFetchedActionTimetoken, middleMinusOnePublishedActionTimetoken);
+                assert.equal(response.data.length, halfSize);
+                assert.equal(response.start, firstPublishedActionTimetoken);
+                assert.equal(response.end, middleMinusOnePublishedActionTimetoken);
+
+                done();
+              });
+          });
+        });
+      });
+    }).timeout(60000);
+  });
+});

--- a/test/unit/networking.test.js
+++ b/test/unit/networking.test.js
@@ -25,7 +25,7 @@ describe('keep-alive agent', () => {
     const networking = setupNetwork(false, false);
     const superagentGetSpy = sinon.spy(superagent, 'get');
 
-    networking.GET({}, { url: '/time/0' }, () => {});
+    networking.GET({}, { url: '/time/0', headers: {} }, () => {});
     assert(superagentGetSpy.called, 'superagent not called with get');
     assert(superagentGetSpy.returnValues[0], 'request instance not created');
     assert(!superagentGetSpy.returnValues[0]._agent, 'keep-alive agent should not be created');
@@ -37,7 +37,7 @@ describe('keep-alive agent', () => {
     const networking = setupNetwork(false, true);
     const superagentGetSpy = sinon.spy(superagent, 'get');
 
-    networking.GET({}, { url: '/time/0' }, () => {});
+    networking.GET({}, { url: '/time/0', headers: {} }, () => {});
     assert(superagentGetSpy.returnValues[0]._agent, 'keep-alive agent not created');
     assert(superagentGetSpy.returnValues[0]._agent.defaultPort !== 443, 'keep-alive agent should access TLS (80) port');
 
@@ -48,8 +48,8 @@ describe('keep-alive agent', () => {
     const networking = setupNetwork(false, true);
     const superagentGetSpy = sinon.spy(superagent, 'get');
 
-    networking.GET({}, { url: '/time/0' }, () => {});
-    networking.GET({}, { url: '/time/0' }, () => {});
+    networking.GET({}, { url: '/time/0', headers: {} }, () => {});
+    networking.GET({}, { url: '/time/0', headers: {} }, () => {});
     assert(superagentGetSpy.returnValues[0]._agent === superagentGetSpy.returnValues[1]._agent, 'same user-agent should be used');
 
     superagentGetSpy.restore();
@@ -59,7 +59,7 @@ describe('keep-alive agent', () => {
     const networking = setupNetwork(true, true);
     const superagentGetSpy = sinon.spy(superagent, 'get');
 
-    networking.GET({}, { url: '/time/0' }, () => {});
+    networking.GET({}, { url: '/time/0', headers: {} }, () => {});
     assert(superagentGetSpy.returnValues[0]._agent, 'keep-alive agent not created');
     assert(superagentGetSpy.returnValues[0]._agent.defaultPort === 443, 'keep-alive agent should access SSL (443) port');
 
@@ -70,8 +70,8 @@ describe('keep-alive agent', () => {
     const networking = setupNetwork(true, true);
     const superagentGetSpy = sinon.spy(superagent, 'get');
 
-    networking.GET({}, { url: '/time/0' }, () => {});
-    networking.GET({}, { url: '/time/0' }, () => {});
+    networking.GET({}, { url: '/time/0', headers: {} }, () => {});
+    networking.GET({}, { url: '/time/0', headers: {} }, () => {});
     assert(superagentGetSpy.returnValues[0]._agent === superagentGetSpy.returnValues[1]._agent, 'same user-agent should be used');
 
     superagentGetSpy.restore();


### PR DESCRIPTION
## ⭐️ Message Actions API

Add Message Actions API support which allow to: 
* `add`
* `remove` 
* `get` previously added actions

## ⭐️ Message Actions API support for History API 

Add new arguments to fetch messages function which allow to fetch previously added actions and message metadata.

## ⭐️ New event handler for message actions

Add new handler which can be used to track message actions addition / removal events.

## ⚙️ Custom headers support

Added endpoint ability to specify custom headers which should be sent along with request.