### PR TITLE
Fix fetchMessage action response and lint warnings

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -23,6 +23,7 @@ const unzip = require('gulp-unzip');
 // increase mocha timeout from default of 2000 to allow long running async tests to complete
 const mochaTimeout = 5000;
 
+gulp.on('error', process.exit.bind(process, 1));
 gulp.task('clean', () => {
   return gulp
     .src(['lib', 'dist', 'coverage', 'upload'], { read: false, allowEmpty: true })

--- a/src/core/endpoints/actions/get_message_actions.js
+++ b/src/core/endpoints/actions/get_message_actions.js
@@ -59,7 +59,7 @@ export function handleResponse(
   getMessageActionsResponse: Object
 ): GetMessageActionsResponse {
   /** @type GetMessageActionsResponse */
-  let response = { data: getMessageActionsResponse.data };
+  let response = { data: getMessageActionsResponse.data, start: null, end: null };
 
   if (response.data.length) {
     response.end = response.data[response.data.length - 1].actionTimetoken;

--- a/src/core/endpoints/fetch_messages.js
+++ b/src/core/endpoints/fetch_messages.js
@@ -98,11 +98,13 @@ export function handleResponse(
     (serverResponse.channels[channelName] || []).forEach((messageEnvelope) => {
       let announce: MessageAnnouncement = {};
       announce.channel = channelName;
-      announce.subscription = null;
       announce.timetoken = messageEnvelope.timetoken;
       announce.message = __processMessage(modules, messageEnvelope.message);
 
       if (messageEnvelope.actions) {
+        announce.actions = messageEnvelope.actions;
+
+        // This should be kept for few updates for existing clients consistency.
         announce.data = messageEnvelope.actions;
       }
       if (messageEnvelope.meta) {

--- a/test/integration/endpoints/grant_token.test.js
+++ b/test/integration/endpoints/grant_token.test.js
@@ -8,6 +8,7 @@ import utils from '../../utils';
 import PubNub from '../../../src/node/index';
 
 describe('grant token endpoint', () => {
+  let originalVersionFunction = null;
   let pubnub;
   let clock;
 
@@ -21,6 +22,7 @@ describe('grant token endpoint', () => {
   after(() => {
     clock.restore();
     nock.enableNetConnect();
+    pubnub._config.getVersion = originalVersionFunction;
   });
 
   beforeEach(() => {
@@ -32,6 +34,11 @@ describe('grant token endpoint', () => {
       uuid: 'myUUID',
       autoNetworkDetection: false,
     });
+
+    if (originalVersionFunction === null) {
+      originalVersionFunction = pubnub._config.getVersion;
+      pubnub._config.getVersion = () => 'testVersion';
+    }
   });
 
   describe('#grantToken', () => {
@@ -44,7 +51,7 @@ describe('grant token endpoint', () => {
             uuid: 'myUUID',
             pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
             timestamp: 1571360790,
-            signature: 'v2.CLurDTyT2OL1mMlQEUHEwfXqXvjSJ_NHTgJvgkG_5ek',
+            signature: 'v2.pJobOYLaDTsauQo8UZa-4Eu4JKYYRuaeyPS8IHpNN-E',
           })
           .reply(
             200,
@@ -75,7 +82,7 @@ describe('grant token endpoint', () => {
             uuid: 'myUUID',
             pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
             timestamp: 1571360790,
-            signature: 'v2.CLurDTyT2OL1mMlQEUHEwfXqXvjSJ_NHTgJvgkG_5ek',
+            signature: 'v2.pJobOYLaDTsauQo8UZa-4Eu4JKYYRuaeyPS8IHpNN-E',
           })
           .reply(
             200,
@@ -111,7 +118,7 @@ describe('grant token endpoint', () => {
             uuid: 'myUUID',
             pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
             timestamp: 1571360790,
-            signature: 'v2.CLurDTyT2OL1mMlQEUHEwfXqXvjSJ_NHTgJvgkG_5ek',
+            signature: 'v2.pJobOYLaDTsauQo8UZa-4Eu4JKYYRuaeyPS8IHpNN-E',
           })
           .reply(
             200,
@@ -147,7 +154,7 @@ describe('grant token endpoint', () => {
             uuid: 'myUUID',
             pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
             timestamp: 1571360790,
-            signature: 'v2.CLurDTyT2OL1mMlQEUHEwfXqXvjSJ_NHTgJvgkG_5ek',
+            signature: 'v2.pJobOYLaDTsauQo8UZa-4Eu4JKYYRuaeyPS8IHpNN-E',
           })
           .reply(
             200,
@@ -183,7 +190,7 @@ describe('grant token endpoint', () => {
             uuid: 'myUUID',
             pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
             timestamp: 1571360790,
-            signature: 'v2.CLurDTyT2OL1mMlQEUHEwfXqXvjSJ_NHTgJvgkG_5ek',
+            signature: 'v2.pJobOYLaDTsauQo8UZa-4Eu4JKYYRuaeyPS8IHpNN-E',
           })
           .reply(
             200,
@@ -220,7 +227,7 @@ describe('grant token endpoint', () => {
           uuid: 'myUUID',
           pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
           timestamp: 1571360790,
-          signature: 'v2.CLurDTyT2OL1mMlQEUHEwfXqXvjSJ_NHTgJvgkG_5ek',
+          signature: 'v2.pJobOYLaDTsauQo8UZa-4Eu4JKYYRuaeyPS8IHpNN-E',
         })
         .reply(
           200,

--- a/test/integration/endpoints/history.test.js
+++ b/test/integration/endpoints/history.test.js
@@ -1,4 +1,4 @@
-/* global describe, beforeEach, afterEach, it, before, after */
+/* global describe, beforeEach, afterEach, it, after */
 /* eslint no-console: 0 */
 
 import assert from 'assert';
@@ -18,22 +18,21 @@ function publishMessagesToChannel(client: PubNub, count: Number, channel: String
     }
 
     client.publish(payload, (status, response) => {
-        publishCompleted++;
+      publishCompleted += 1;
 
-        if (!status.error) {
-          messages.push({ message: payload.message, timetoken: response.timetoken });
-          messages = messages.sort((left, right) => left.timetoken - right.timetoken);
-        } else {
-          console.error('Publish did fail:', status);
-        }
-
-        if (publishCompleted < count) {
-          publish(publishCompleted);
-        } else if (publishCompleted === count) {
-          completion(messages);
-        }
+      if (!status.error) {
+        messages.push({ message: payload.message, timetoken: response.timetoken });
+        messages = messages.sort((left, right) => left.timetoken - right.timetoken);
+      } else {
+        console.error('Publish did fail:', status);
       }
-    );
+
+      if (publishCompleted < count) {
+        publish(publishCompleted);
+      } else if (publishCompleted === count) {
+        completion(messages);
+      }
+    });
   };
 
   publish(publishCompleted);
@@ -59,8 +58,8 @@ describe('history endpoints', () => {
   beforeEach(() => {
     nock.cleanAll();
     pubnub = new PubNub({
-      subscribeKey: subscribeKey,
-      publishKey: publishKey,
+      subscribeKey,
+      publishKey,
       uuid: 'myUUID',
     });
   });

--- a/test/integration/endpoints/message_actions.test.js
+++ b/test/integration/endpoints/message_actions.test.js
@@ -1,10 +1,10 @@
-/* global describe, beforeEach, afterEach, it, before, after, jasmine */
+/* global describe, beforeEach, afterEach, it, after */
 /* eslint no-console: 0 */
 
-import PubNub from '../../../src/node/index';
-import utils from "../../utils";
 import assert from 'assert';
 import nock from 'nock';
+import PubNub from '../../../src/node/index';
+import utils from '../../utils';
 
 
 function publishMessages(client: PubNub, count: Number, channel: String, completion: Function) {
@@ -17,7 +17,7 @@ function publishMessages(client: PubNub, count: Number, channel: String, complet
     client.publish(
       { message, channel },
       (status, response) => {
-        publishCompleted++;
+        publishCompleted += 1;
 
         if (!status.error) {
           timetokens.push(response.timetoken);
@@ -47,10 +47,10 @@ function addActions(client: PubNub, count: Number, messageTimetokens: Array<Numb
   let actionsAdded = 0;
   let timetokens = [];
 
-  for (let messageIdx = 0; messageIdx < messageTimetokens.length; messageIdx++) {
+  for (let messageIdx = 0; messageIdx < messageTimetokens.length; messageIdx += 1) {
     const messageTimetoken = messageTimetokens[messageIdx];
 
-    for (let messageActionIdx = 0; messageActionIdx < count; messageActionIdx++) {
+    for (let messageActionIdx = 0; messageActionIdx < count; messageActionIdx += 1) {
       /** @type MessageAction */
       const action = { type: types[(messageActionIdx + 1) % 3], value: values[(messageActionIdx + 1) % 10] };
 
@@ -64,7 +64,7 @@ function addActions(client: PubNub, count: Number, messageTimetokens: Array<Numb
     client.addMessageAction(
       { channel, messageTimetoken, action },
       (status, response) => {
-        actionsAdded++;
+        actionsAdded += 1;
 
         if (!status.error) {
           timetokens.push(response.data.actionTimetoken);
@@ -104,8 +104,8 @@ describe('message actions endpoints', () => {
   beforeEach(() => {
     nock.cleanAll();
     pubnub = new PubNub({
-      subscribeKey: subscribeKey,
-      publishKey: publishKey,
+      subscribeKey,
+      publishKey,
       uuid: 'myUUID',
       authKey: 'myAuthKey',
     });
@@ -117,13 +117,13 @@ describe('message actions endpoints', () => {
         nock.disableNetConnect();
         const scope = utils
           .createNock()
-            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
-            .reply(200, {});
+          .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
+          .reply(200, {});
 
         pubnub.addMessageAction({
-            channel: 'test-channel',
-            messageTimetoken: '1234567890',
-          })
+          channel: 'test-channel',
+          messageTimetoken: '1234567890',
+        })
           .catch((err) => {
             assert.equal(scope.isDone(), false);
             assert.equal(err.status.message, 'Missing Action');
@@ -135,15 +135,15 @@ describe('message actions endpoints', () => {
         nock.disableNetConnect();
         const scope = utils
           .createNock()
-            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
-            .reply(200, {});
+          .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
+          .reply(200, {});
         const action = { value: 'test value' };
 
         pubnub.addMessageAction({
-            channel: 'test-channel',
-            messageTimetoken: '1234567890',
-            action,
-          })
+          channel: 'test-channel',
+          messageTimetoken: '1234567890',
+          action,
+        })
           .catch((err) => {
             assert.equal(scope.isDone(), false);
             assert.equal(err.status.message, 'Missing Action.type');
@@ -155,15 +155,15 @@ describe('message actions endpoints', () => {
         nock.disableNetConnect();
         const scope = utils
           .createNock()
-            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
-            .reply(200, {});
+          .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
+          .reply(200, {});
         const action = { type: PubNub.generateUUID(), value: 'test value' };
 
         pubnub.addMessageAction({
-            channel: 'test-channel',
-            messageTimetoken: '1234567890',
-            action,
-          })
+          channel: 'test-channel',
+          messageTimetoken: '1234567890',
+          action,
+        })
           .catch((err) => {
             assert.equal(scope.isDone(), false);
             assert.equal(err.status.message, 'Action.type value exceed maximum length of 15');
@@ -175,15 +175,15 @@ describe('message actions endpoints', () => {
         nock.disableNetConnect();
         const scope = utils
           .createNock()
-            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
-            .reply(200, {});
+          .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
+          .reply(200, {});
         const action = { type: 'custom' };
 
         pubnub.addMessageAction({
-            channel: 'test-channel',
-            messageTimetoken: '1234567890',
-            action,
-          })
+          channel: 'test-channel',
+          messageTimetoken: '1234567890',
+          action,
+        })
           .catch((err) => {
             assert.equal(scope.isDone(), false);
             assert.equal(err.status.message, 'Missing Action.value');
@@ -195,14 +195,14 @@ describe('message actions endpoints', () => {
         nock.disableNetConnect();
         const scope = utils
           .createNock()
-            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/`)
-            .reply(200, {});
+          .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/`)
+          .reply(200, {});
         const action = { type: 'custom', value: 'test value' };
 
         pubnub.addMessageAction({
-            channel: 'test-channel',
-            action,
-          })
+          channel: 'test-channel',
+          action,
+        })
           .catch((err) => {
             assert.equal(scope.isDone(), false);
             assert.equal(err.status.message, 'Missing message timetoken');
@@ -214,14 +214,14 @@ describe('message actions endpoints', () => {
         nock.disableNetConnect();
         const scope = utils
           .createNock()
-            .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
-            .reply(200, {});
+          .post(`/v1/message-actions/${subscribeKey}/channel/test-channel/message/1234567890`)
+          .reply(200, {});
         const action = { type: 'custom', value: 'test value' };
 
         pubnub.addMessageAction({
-            messageTimetoken: '1234567890',
-            action,
-          })
+          messageTimetoken: '1234567890',
+          action,
+        })
           .catch((err) => {
             assert.equal(scope.isDone(), false);
             assert.equal(err.status.message, 'Missing message channel');
@@ -235,9 +235,9 @@ describe('message actions endpoints', () => {
       const messageAction = { type: 'custom', value: PubNub.generateUUID() };
       const channel = PubNub.generateUUID();
 
-      publishMessages(pubnub,1, channel, (timetokens) => {
+      publishMessages(pubnub, 1, channel, (timetokens) => {
         pubnub.addMessageAction(
-          { channel: channel, messageTimetoken: timetokens[0], action: messageAction },
+          { channel, messageTimetoken: timetokens[0], action: messageAction },
           (status, response) => {
             assert.equal(status.error, false);
             assert.equal(response.data.type, messageAction.type);
@@ -263,23 +263,23 @@ describe('message actions endpoints', () => {
           auth: 'myAuthKey'
         })
         .reply(207, {
-          "status": 207,
-          "data": {
-            "type": "reaction",
-            "value": "smiley_face",
-            "uuid": "user-456",
-            "actionTimetoken": '15610547826970050',
-            "messageTimetoken": '15610547826969050'
+          status: 207,
+          data: {
+            type: 'reaction',
+            value: 'smiley_face',
+            uuid: 'user-456',
+            actionTimetoken: '15610547826970050',
+            messageTimetoken: '15610547826969050'
           },
-          "error": {
-            "message": "Stored but failed to publish message action.",
-            "source": "actions"
+          error: {
+            message: 'Stored but failed to publish message action.',
+            source: 'actions'
           }
         });
 
       pubnub.addMessageAction(
         { channel: 'test-channel', messageTimetoken: '1234567890', action: { type: 'custom', value: 'test' } },
-         (status, response) => {
+        (status) => {
           assert.equal(scope.isDone(), true);
           assert.equal(status.statusCode, 207);
           assert(status.errorData.message);
@@ -300,7 +300,7 @@ describe('message actions endpoints', () => {
           if (status.category === 'PNConnectedCategory') {
             pubnub.publish(
               { channel, message: { hello: 'test' }, sendByPost: true },
-              (status, response) => {
+              (publishStatus, response) => {
                 messageTimetoken = response.timetoken;
 
                 pubnub.addMessageAction(
@@ -337,9 +337,9 @@ describe('message actions endpoints', () => {
           .reply(200, {});
 
         pubnub.removeMessageAction({
-            channel: 'test-channel',
-            actionTimetoken: '1234567890',
-          })
+          channel: 'test-channel',
+          actionTimetoken: '1234567890',
+        })
           .catch((err) => {
             assert.equal(scope.isDone(), false);
             assert.equal(err.status.message, 'Missing message timetoken');
@@ -356,9 +356,9 @@ describe('message actions endpoints', () => {
           .reply(200, {});
 
         pubnub.removeMessageAction({
-            channel: 'test-channel',
-            messageTimetoken: '1234567890',
-          })
+          channel: 'test-channel',
+          messageTimetoken: '1234567890',
+        })
           .catch((err) => {
             assert.equal(scope.isDone(), false);
             assert.equal(err.status.message, 'Missing action timetoken');
@@ -375,9 +375,9 @@ describe('message actions endpoints', () => {
           .reply(200, {});
 
         pubnub.removeMessageAction({
-            messageTimetoken: '1234567890',
-            actionTimetoken: '12345678901',
-          })
+          messageTimetoken: '1234567890',
+          actionTimetoken: '12345678901',
+        })
           .catch((err) => {
             assert.equal(scope.isDone(), false);
             assert.equal(err.status.message, 'Missing message channel');
@@ -398,13 +398,13 @@ describe('message actions endpoints', () => {
 
             pubnub.removeMessageAction(
               { channel, actionTimetoken: actionTimetokens[0], messageTimetoken: messageTimetokens[0] },
-              (status) => {
-                assert.equal(status.error, false);
+              (removeMessageStatus) => {
+                assert.equal(removeMessageStatus.error, false);
 
                 setTimeout(() => {
-                  pubnub.getMessageActions({ channel }, (status, response) => {
-                    assert.equal(status.error, false);
-                    assert.equal(response.data.length, 0);
+                  pubnub.getMessageActions({ channel }, (getMessagesStatus, getMessagesResponse) => {
+                    assert.equal(getMessagesStatus.error, false);
+                    assert.equal(getMessagesResponse.data.length, 0);
 
                     done();
                   });
@@ -425,9 +425,9 @@ describe('message actions endpoints', () => {
             status: (status) => {
               if (status.category === 'PNConnectedCategory') {
                 pubnub.removeMessageAction(
-                  {channel, actionTimetoken: actionTimetokens[0], messageTimetoken: messageTimetokens[0]},
-                  (status) => {
-                    assert.equal(status.error, false);
+                  { channel, actionTimetoken: actionTimetokens[0], messageTimetoken: messageTimetokens[0] },
+                  (removeMessagesStatus) => {
+                    assert.equal(removeMessagesStatus.error, false);
                   }
                 );
               }
@@ -504,8 +504,8 @@ describe('message actions endpoints', () => {
 
           pubnub.getMessageActions({ channel, limit: halfSize }, (status, response) => {
             assert.equal(status.error, false);
-            const firstFetchedActionTimetoken = response.data[0].actionTimetoken;
-            const lastFetchedActionTimetoken = response.data[response.data.length - 1].actionTimetoken;
+            let firstFetchedActionTimetoken = response.data[0].actionTimetoken;
+            let lastFetchedActionTimetoken = response.data[response.data.length - 1].actionTimetoken;
             assert.equal(firstFetchedActionTimetoken, middlePublishedActionTimetoken);
             assert.equal(lastFetchedActionTimetoken, lastPublishedActionTimetoken);
             assert.equal(response.data.length, halfSize);
@@ -514,18 +514,19 @@ describe('message actions endpoints', () => {
 
             pubnub.getMessageActions(
               { channel, start: middlePublishedActionTimetoken, limit: halfSize },
-              (status, response) => {
-                assert.equal(status.error, false);
-                const firstFetchedActionTimetoken = response.data[0].actionTimetoken;
-                const lastFetchedActionTimetoken = response.data[response.data.length - 1].actionTimetoken;
+              (getMessageActionsStatus, getMessageActionsResponse) => {
+                assert.equal(getMessageActionsStatus.error, false);
+                firstFetchedActionTimetoken = getMessageActionsResponse.data[0].actionTimetoken;
+                lastFetchedActionTimetoken = getMessageActionsResponse.data[getMessageActionsResponse.data.length - 1].actionTimetoken;
                 assert.equal(firstFetchedActionTimetoken, firstPublishedActionTimetoken);
                 assert.equal(lastFetchedActionTimetoken, middleMinusOnePublishedActionTimetoken);
-                assert.equal(response.data.length, halfSize);
-                assert.equal(response.start, firstPublishedActionTimetoken);
-                assert.equal(response.end, middleMinusOnePublishedActionTimetoken);
+                assert.equal(getMessageActionsResponse.data.length, halfSize);
+                assert.equal(getMessageActionsResponse.start, firstPublishedActionTimetoken);
+                assert.equal(getMessageActionsResponse.end, middleMinusOnePublishedActionTimetoken);
 
                 done();
-              });
+              }
+            );
           });
         });
       });


### PR DESCRIPTION
## 🛠 _message-actions_: move message actions to another variable

Make changes in `fetch_messages` endpoint to move message actions (if any) for message from  `data` to `actions` property (old `data` will be in place for few updates to not break existing clients).

## 🧪 _tests_ : fix PAMv3 tests mocked signature

Make sure, that we don't include dynamic `pnsdk` into generated signature, so it won't break each time new version released.

## 🎛 _refactor_: fix lint warnings for tests and code

Make changes according to linter and flow checkers.