### PR TITLE
Add APNS over HTTP/2 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pubnub",
-  "version": "4.27.1",
+  "version": "4.27.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/core/components/push_payload.js
+++ b/src/core/components/push_payload.js
@@ -1,0 +1,537 @@
+/* @flow */
+import { APNS2Configuration, APNS2Target } from '../flow_interfaces'
+
+class BaseNotificationPayload {
+  _subtitle: ?string;
+  _payload: Object;
+  _badge: ?number;
+  _sound: ?string;
+  _title: ?string;
+  _body: ?string;
+
+  get payload() {
+    return this._payload;
+  }
+
+  set title(value: ?string) {
+    this._title = value;
+  }
+
+  set subtitle(value: ?string) {
+    this._subtitle = value;
+  }
+
+  set body(value: ?string) {
+    this._body = value;
+  }
+
+  set badge(value: ?number) {
+    this._badge = value;
+  }
+
+  set sound(value: ?string) {
+    this._sound = value;
+  }
+
+  constructor(payload: Object, title: ?string, body: ?string) {
+    this._payload = payload;
+
+    this._setDefaultPayloadStructure();
+    this.title = title;
+    this.body = body;
+  }
+
+  _setDefaultPayloadStructure() {
+  }
+
+  toObject() {
+    return {};
+  }
+}
+
+export class APNSNotificationPayload extends BaseNotificationPayload {
+  _configurations: Array<APNS2Configuration>;
+  _apnsPushType: ?string;
+  _isSilent: boolean;
+
+  set configurations(value: Array<APNS2Configuration>) {
+    if (!value || !value.length) return;
+
+    this._configurations = value;
+  }
+
+  get notification() {
+    return this._payload.aps;
+  }
+
+  get title() {
+    return this._title;
+  }
+
+  set title(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.aps.alert.title = value;
+    this._title = value;
+  }
+
+  get subtitle() {
+    return this._subtitle;
+  }
+
+  set subtitle(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.aps.alert.subtitle = value;
+    this._subtitle = value;
+  }
+
+  get body() {
+    return this._body;
+  }
+
+  set body(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.aps.alert.body = value;
+    this._body = value;
+  }
+
+  get badge() {
+    return this._badge;
+  }
+
+  set badge(value: ?number) {
+    if (value === undefined || value === null) return;
+
+    this._payload.aps.badge = value;
+    this._badge = value;
+  }
+
+  get sound() {
+    return this._sound;
+  }
+
+  set sound(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.aps.sound = value;
+    this._sound = value;
+  }
+
+  set silent(value: boolean) {
+    this._isSilent = value;
+  }
+
+  _setDefaultPayloadStructure() {
+    this._payload.aps = { alert: {} };
+  }
+
+  toObject(): ?Object {
+    let payload = Object.assign({}, this._payload);
+    /** @type {{alert: Object, badge: number, sound: string}} */
+    let aps = payload.aps;
+    let alert = aps.alert;
+
+    if (this._isSilent) {
+      aps['content-available'] = 1;
+    }
+
+    if (this._apnsPushType === 'apns2') {
+      if (!this._configurations || !this._configurations.length) {
+        throw new ReferenceError('APNS2 configuration is missing');
+      }
+
+      let configurations = [];
+      this._configurations.forEach((configuration: APNS2Configuration) => {
+        configurations.push(this._objectFromAPNS2Configuration(configuration));
+      });
+
+      if (configurations.length) {
+        payload.pn_push = configurations;
+      }
+    }
+
+    if (!alert || !Object.keys(alert).length) {
+      delete aps.alert;
+    }
+
+    if (this._isSilent) {
+      delete aps.alert;
+      delete aps.badge;
+      delete aps.sound;
+      alert = {};
+    }
+
+    return this._isSilent || Object.keys(alert).length ? payload : null;
+  }
+
+  _objectFromAPNS2Configuration(configuration: APNS2Configuration) {
+    if (!configuration.targets || !configuration.targets.length) {
+      throw new ReferenceError('At least one APNS2 target should be provided');
+    }
+
+    let targets = [];
+    configuration.targets.forEach((target: APNS2Target) => {
+      targets.push(this._objectFromAPNSTarget(target));
+    });
+
+    const { collapseId, date } = configuration;
+    let objectifiedConfiguration: {
+      auth_method: string,
+      targets: Array<Object>,
+      version: string,
+      collapse_id?: string,
+      expiration?: string
+    } = { 'auth_method': 'token', targets, 'version': 'v2' };
+
+    if (collapseId && collapseId.length) {
+      objectifiedConfiguration.collapse_id = collapseId;
+    }
+
+    if (date) {
+      objectifiedConfiguration.expiration = date.toISOString();
+    }
+
+    return objectifiedConfiguration;
+  }
+
+  _objectFromAPNSTarget(target: APNS2Target) {
+    if (!target.topic || !target.topic.length) {
+      throw new TypeError('Target \'topic\' undefined.');
+    }
+
+    const {
+      topic,
+      environment = 'development',
+      excludedDevices = []
+    } = target;
+
+    let objectifiedTarget: {
+      topic: string,
+      environment: string,
+      excluded_devices?: Array<string>
+    } = { topic, environment };
+
+    if (excludedDevices.length) {
+      objectifiedTarget.excluded_devices = excludedDevices;
+    }
+
+    return objectifiedTarget;
+  }
+}
+
+export class MPNSNotificationPayload extends BaseNotificationPayload  {
+  _backContent: ?string;
+  _backTitle: ?string;
+  _count: ?number;
+  _type: ?string;
+
+  get backContent() {
+    return this._backContent;
+  }
+
+  set backContent(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.back_content = value;
+    this._backContent = value;
+  }
+
+  get backTitle() {
+    return this._backTitle;
+  }
+
+  set backTitle(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.back_title = value;
+    this._backTitle = value;
+  }
+
+  get count() {
+    return this._count;
+  }
+
+  set count(value: ?number) {
+    if (value === undefined || value === null) return;
+
+    this._payload.count = value;
+    this._count = value;
+  }
+
+  get title() {
+    return this._title;
+  }
+
+  set title(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.title = value;
+    this._title = value;
+  }
+
+  get type() {
+    return this._type;
+  }
+
+  set type(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.type = value;
+    this._type = value;
+  }
+
+  get subtitle() {
+    return this.backTitle;
+  }
+
+  set subtitle(value: ?string) {
+    this.backTitle = value;
+  }
+
+  get body() {
+    return self.backContent;
+  }
+
+  set body(value: ?string) {
+    this.backContent = value;
+  }
+
+  get badge() {
+    return this.count;
+  }
+
+  set badge(value: ?number) {
+    this.count = value;
+  }
+
+  toObject(): ?Object {
+    return Object.keys(this._payload).length ? Object.assign({}, this._payload) : null;
+  }
+}
+
+export class FCMNotificationPayload extends BaseNotificationPayload  {
+  _isSilent: boolean;
+  _icon: ?string;
+  _tag: ?string;
+
+  get notification() {
+    return this._payload.notification;
+  }
+
+  get data() {
+    return this._payload.data;
+  }
+
+  get title() {
+    return this._title;
+  }
+
+  set title(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.notification.title = value;
+    this._title = value;
+  }
+
+  get body() {
+    return this._body;
+  }
+
+  set body(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.notification.body = value;
+    this._body = value;
+  }
+
+  get sound() {
+    return this._sound;
+  }
+
+  set sound(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.notification.sound = value;
+    this._sound = value;
+  }
+
+  get icon() {
+    return this._icon;
+  }
+
+  set icon(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.notification.icon = value;
+    this._icon = value;
+  }
+
+  get tag() {
+    return this._tag;
+  }
+
+  set tag(value: ?string) {
+    if (!value || !value.length) return;
+
+    this._payload.notification.tag = value;
+    this._tag = value;
+  }
+
+  set silent(value: boolean) {
+    this._isSilent = value;
+  }
+
+  _setDefaultPayloadStructure() {
+    this._payload.notification = {};
+    this._payload.data = {};
+  }
+
+  toObject(): ?Object {
+    let data = Object.assign({}, this._payload.data);
+    let notification = null;
+    let payload = {};
+
+    /**
+     * Check whether additional data has been passed outside of 'data' object
+     * and put it into it if required.
+     */
+    if (Object.keys(this._payload).length > 2) {
+      let { notification, data: initialData, ...additionalData } = this._payload;
+
+      data = Object.assign({}, data, additionalData);
+    }
+
+    if (this._isSilent) {
+      data.notification = this._payload.notification;
+    } else {
+      notification = this._payload.notification;
+    }
+
+    if (Object.keys(data).length) {
+      payload.data = data;
+    }
+
+    if (notification && Object.keys(notification).length) {
+      payload.notification = notification;
+    }
+
+    return Object.keys(payload).length ? payload : null;
+  }
+}
+
+class NotificationsPayload {
+  _payload: {apns: Object, mpns: Object, fcm: Object};
+  _debugging: boolean;
+  _subtitle: ?string;
+  _badge: ?number;
+  _sound: ?string;
+  _title: ?string;
+  _body: ?string;
+  apns: APNSNotificationPayload;
+  mpns: MPNSNotificationPayload;
+  fcm: FCMNotificationPayload;
+
+  set debugging(value: boolean) {
+    this._debugging = value;
+  }
+
+  get title() {
+    return this._title;
+  }
+
+  get body() {
+    return this._body;
+  }
+
+  get subtitle() {
+    return this._subtitle;
+  }
+
+  set subtitle(value: ?string) {
+    this._subtitle = value;
+    this.apns.subtitle = value;
+    this.mpns.subtitle = value;
+    this.fcm.subtitle = value;
+  }
+
+  get badge() {
+    return this._badge;
+  }
+
+  set badge(value: ?number) {
+    this._badge = value;
+    this.apns.badge = value;
+    this.mpns.badge = value;
+    this.fcm.badge = value;
+  }
+
+  get sound() {
+    return this._sound;
+  }
+
+  set sound(value: ?string) {
+    this._sound = value;
+    this.apns.sound = value;
+    this.mpns.sound = value;
+    this.fcm.sound = value;
+  }
+
+  constructor(title: ?string, body: ?string) {
+    this._payload = { apns: {}, mpns: {}, fcm: {} };
+    this._title = title;
+    this._body = body;
+
+    this.apns = new APNSNotificationPayload(this._payload.apns, title, body);
+    this.mpns = new MPNSNotificationPayload(this._payload.mpns, title, body);
+    this.fcm = new FCMNotificationPayload(this._payload.fcm, title, body);
+  }
+
+  /**
+   * Build notifications platform for requested platforms.
+   *
+   * @param {Array<string>} platforms - List of platforms for which payload
+   * should be added to final dictionary. Supported values: gcm, apns, apns2,
+   * mpns.
+   *
+   * @returns {Object} Object with data, which can be sent with publish method
+   * call and trigger remote notifications for specified platforms.
+   */
+  buildPayload(platforms: Array<string>) {
+    let payload = {};
+
+    if (platforms.includes('apns') || platforms.includes('apns2')) {
+      this.apns._apnsPushType = platforms.includes('apns') ? 'apns' : 'apns2';
+      let apnsPayload = this.apns.toObject();
+
+      if (apnsPayload && Object.keys(apnsPayload).length) {
+        payload.pn_apns = apnsPayload;
+      }
+    }
+
+    if (platforms.includes('mpns')) {
+      let mpnsPayload = this.mpns.toObject();
+
+      if (mpnsPayload && Object.keys(mpnsPayload).length) {
+        payload.pn_mpns = mpnsPayload;
+      }
+    }
+
+    if (platforms.includes('fcm')) {
+      let fcmPayload = this.fcm.toObject();
+
+      if (fcmPayload && Object.keys(fcmPayload).length) {
+        payload.pn_gcm = fcmPayload;
+      }
+    }
+
+    if (Object.keys(payload).length && this._debugging) {
+      payload.pn_debug = true;
+    }
+
+    return payload;
+  }
+}
+
+export default NotificationsPayload;

--- a/src/core/components/push_payload.js
+++ b/src/core/components/push_payload.js
@@ -176,7 +176,7 @@ export class APNSNotificationPayload extends BaseNotificationPayload {
       targets.push(this._objectFromAPNSTarget(target));
     });
 
-    const { collapseId, date } = configuration;
+    const { collapseId, expirationDate } = configuration;
     let objectifiedConfiguration: {
       auth_method: string,
       targets: Array<Object>,
@@ -189,8 +189,8 @@ export class APNSNotificationPayload extends BaseNotificationPayload {
       objectifiedConfiguration.collapse_id = collapseId;
     }
 
-    if (date) {
-      objectifiedConfiguration.expiration = date.toISOString();
+    if (expirationDate) {
+      objectifiedConfiguration.expiration = expirationDate.toISOString();
     }
 
     return objectifiedConfiguration;

--- a/src/core/components/push_payload.js
+++ b/src/core/components/push_payload.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { APNS2Configuration, APNS2Target } from '../flow_interfaces'
+import { APNS2Configuration, APNS2Target } from '../flow_interfaces';
 
 class BaseNotificationPayload {
   _subtitle: ?string;
@@ -183,7 +183,7 @@ export class APNSNotificationPayload extends BaseNotificationPayload {
       version: string,
       collapse_id?: string,
       expiration?: string
-    } = { 'auth_method': 'token', targets, 'version': 'v2' };
+    } = { auth_method: 'token', targets, version: 'v2' };
 
     if (collapseId && collapseId.length) {
       objectifiedConfiguration.collapse_id = collapseId;
@@ -291,7 +291,7 @@ export class MPNSNotificationPayload extends BaseNotificationPayload  {
   }
 
   get body() {
-    return self.backContent;
+    return this.backContent;
   }
 
   set body(value: ?string) {
@@ -398,7 +398,7 @@ export class FCMNotificationPayload extends BaseNotificationPayload  {
      * and put it into it if required.
      */
     if (Object.keys(this._payload).length > 2) {
-      let { notification, data: initialData, ...additionalData } = this._payload;
+      let { notification: initialNotification, data: initialData, ...additionalData } = this._payload;
 
       data = Object.assign({}, data, additionalData);
     }

--- a/src/core/endpoints/push/add_push_channels.js
+++ b/src/core/endpoints/push/add_push_channels.js
@@ -45,7 +45,7 @@ export function prepareParams(modules: ModulesInject, incomingParams: ModifyDevi
   let parameters = { type: pushGateway, add: channels.join(',') };
 
   if (pushGateway === 'apns2') {
-    Object.assign(parameters, { environment, topic });
+    parameters = Object.assign({}, parameters, { environment, topic });
     delete parameters.type;
   }
 

--- a/src/core/endpoints/push/add_push_channels.js
+++ b/src/core/endpoints/push/add_push_channels.js
@@ -13,12 +13,9 @@ export function validateParams(modules: ModulesInject, incomingParams: ModifyDev
 
   if (!device) return 'Missing Device ID (device)';
   if (!pushGateway) return 'Missing GW Type (pushGateway: gcm, apns or apns2)';
+  if (pushGateway === 'apns2' && !topic) return 'Missing APNS2 topic';
   if (!channels || channels.length === 0) return 'Missing Channels';
   if (!config.subscribeKey) return 'Missing Subscribe Key';
-
-  if (pushGateway === 'apns2') {
-    if (!topic) return 'Missing APNS2 topic';
-  }
 }
 
 export function getURL(modules: ModulesInject, incomingParams: ModifyDeviceArgs): string {

--- a/src/core/endpoints/push/list_push_channels.js
+++ b/src/core/endpoints/push/list_push_channels.js
@@ -8,17 +8,26 @@ export function getOperation(): string {
 }
 
 export function validateParams(modules: ModulesInject, incomingParams: ListChannelsArgs) {
-  let { device, pushGateway } = incomingParams;
+  let { device, pushGateway, topic } = incomingParams;
   let { config } = modules;
 
   if (!device) return 'Missing Device ID (device)';
-  if (!pushGateway) return 'Missing GW Type (pushGateway: gcm or apns)';
+  if (!pushGateway) return 'Missing GW Type (pushGateway: gcm, apns or apns2)';
   if (!config.subscribeKey) return 'Missing Subscribe Key';
+
+  if (pushGateway === 'apns2') {
+    if (!topic) return 'Missing APNS2 topic';
+  }
 }
 
 export function getURL(modules: ModulesInject, incomingParams: ListChannelsArgs): string {
-  let { device } = incomingParams;
+  let { device, pushGateway } = incomingParams;
   let { config } = modules;
+
+  if (pushGateway === 'apns2') {
+    return `/v2/push/sub-key/${config.subscribeKey}/devices-apns2/${device}`;
+  }
+
   return `/v1/push/sub-key/${config.subscribeKey}/devices/${device}`;
 }
 
@@ -31,8 +40,15 @@ export function isAuthSupported() {
 }
 
 export function prepareParams(modules: ModulesInject, incomingParams: ListChannelsArgs): Object {
-  let { pushGateway } = incomingParams;
-  return { type: pushGateway };
+  let { pushGateway, environment = 'development', topic } = incomingParams;
+  let parameters = { type: pushGateway };
+
+  if (pushGateway === 'apns2') {
+    Object.assign(parameters, { environment, topic });
+    delete parameters.type;
+  }
+
+  return parameters;
 }
 
 export function handleResponse(modules: ModulesInject, serverResponse: Array<string>): ListChannelsResponse {

--- a/src/core/endpoints/push/list_push_channels.js
+++ b/src/core/endpoints/push/list_push_channels.js
@@ -13,11 +13,8 @@ export function validateParams(modules: ModulesInject, incomingParams: ListChann
 
   if (!device) return 'Missing Device ID (device)';
   if (!pushGateway) return 'Missing GW Type (pushGateway: gcm, apns or apns2)';
+  if (pushGateway === 'apns2' && !topic) return 'Missing APNS2 topic';
   if (!config.subscribeKey) return 'Missing Subscribe Key';
-
-  if (pushGateway === 'apns2') {
-    if (!topic) return 'Missing APNS2 topic';
-  }
 }
 
 export function getURL(modules: ModulesInject, incomingParams: ListChannelsArgs): string {

--- a/src/core/endpoints/push/list_push_channels.js
+++ b/src/core/endpoints/push/list_push_channels.js
@@ -44,7 +44,7 @@ export function prepareParams(modules: ModulesInject, incomingParams: ListChanne
   let parameters = { type: pushGateway };
 
   if (pushGateway === 'apns2') {
-    Object.assign(parameters, { environment, topic });
+    parameters = Object.assign({}, parameters, { environment, topic });
     delete parameters.type;
   }
 

--- a/src/core/endpoints/push/remove_device.js
+++ b/src/core/endpoints/push/remove_device.js
@@ -13,11 +13,8 @@ export function validateParams(modules: ModulesInject, incomingParams: RemoveDev
 
   if (!device) return 'Missing Device ID (device)';
   if (!pushGateway) return 'Missing GW Type (pushGateway: gcm, apns or apns2)';
+  if (pushGateway === 'apns2' && !topic) return 'Missing APNS2 topic';
   if (!config.subscribeKey) return 'Missing Subscribe Key';
-
-  if (pushGateway === 'apns2') {
-    if (!topic) return 'Missing APNS2 topic';
-  }
 }
 
 export function getURL(modules: ModulesInject, incomingParams: RemoveDeviceArgs): string {

--- a/src/core/endpoints/push/remove_device.js
+++ b/src/core/endpoints/push/remove_device.js
@@ -44,7 +44,7 @@ export function prepareParams(modules: ModulesInject, incomingParams: RemoveDevi
   let parameters = { type: pushGateway };
 
   if (pushGateway === 'apns2') {
-    Object.assign(parameters, { environment, topic });
+    parameters = Object.assign({}, parameters, { environment, topic });
     delete parameters.type;
   }
 

--- a/src/core/endpoints/push/remove_push_channels.js
+++ b/src/core/endpoints/push/remove_push_channels.js
@@ -45,7 +45,7 @@ export function prepareParams(modules: ModulesInject, incomingParams: ModifyDevi
   let parameters = { type: pushGateway, remove: channels.join(',') };
 
   if (pushGateway === 'apns2') {
-    Object.assign(parameters, { environment, topic });
+    parameters = Object.assign({}, parameters, { environment, topic });
     delete parameters.type;
   }
 

--- a/src/core/endpoints/push/remove_push_channels.js
+++ b/src/core/endpoints/push/remove_push_channels.js
@@ -8,18 +8,27 @@ export function getOperation(): string {
 }
 
 export function validateParams(modules: ModulesInject, incomingParams: ModifyDeviceArgs) {
-  let { device, pushGateway, channels } = incomingParams;
+  let { device, pushGateway, channels, topic } = incomingParams;
   let { config } = modules;
 
   if (!device) return 'Missing Device ID (device)';
-  if (!pushGateway) return 'Missing GW Type (pushGateway: gcm or apns)';
+  if (!pushGateway) return 'Missing GW Type (pushGateway: gcm, apns or apns2)';
   if (!channels || channels.length === 0) return 'Missing Channels';
   if (!config.subscribeKey) return 'Missing Subscribe Key';
+
+  if (pushGateway === 'apns2') {
+    if (!topic) return 'Missing APNS2 topic';
+  }
 }
 
 export function getURL(modules: ModulesInject, incomingParams: ModifyDeviceArgs): string {
-  let { device } = incomingParams;
+  let { device, pushGateway } = incomingParams;
   let { config } = modules;
+
+  if (pushGateway === 'apns2') {
+    return `/v2/push/sub-key/${config.subscribeKey}/devices-apns2/${device}`;
+  }
+
   return `/v1/push/sub-key/${config.subscribeKey}/devices/${device}`;
 }
 
@@ -32,8 +41,15 @@ export function isAuthSupported() {
 }
 
 export function prepareParams(modules: ModulesInject, incomingParams: ModifyDeviceArgs): Object {
-  let { pushGateway, channels = [] } = incomingParams;
-  return { type: pushGateway, remove: channels.join(',') };
+  let { pushGateway, channels = [], environment = 'development', topic } = incomingParams;
+  let parameters = { type: pushGateway, remove: channels.join(',') };
+
+  if (pushGateway === 'apns2') {
+    Object.assign(parameters, { environment, topic });
+    delete parameters.type;
+  }
+
+  return parameters;
 }
 
 export function handleResponse(): Object {

--- a/src/core/endpoints/push/remove_push_channels.js
+++ b/src/core/endpoints/push/remove_push_channels.js
@@ -13,12 +13,9 @@ export function validateParams(modules: ModulesInject, incomingParams: ModifyDev
 
   if (!device) return 'Missing Device ID (device)';
   if (!pushGateway) return 'Missing GW Type (pushGateway: gcm, apns or apns2)';
+  if (pushGateway === 'apns2' && !topic) return 'Missing APNS2 topic';
   if (!channels || channels.length === 0) return 'Missing Channels';
   if (!config.subscribeKey) return 'Missing Subscribe Key';
-
-  if (pushGateway === 'apns2') {
-    if (!topic) return 'Missing APNS2 topic';
-  }
 }
 
 export function getURL(modules: ModulesInject, incomingParams: ModifyDeviceArgs): string {

--- a/src/core/flow_interfaces.js
+++ b/src/core/flow_interfaces.js
@@ -296,34 +296,46 @@ type ListChannelsResponse = {
 
 // push
 
+export type APNS2Target = {
+  topic: string,
+  environment?: 'development' | 'production',
+  excludedDevices?: Array<string>
+}
+
+export type APNS2Configuration = {
+  collapseId?: string,
+  date?: Date,
+  targets: Array<APNS2Target>
+}
+
 type ProvisionDeviceArgs = {
   operation: 'add' | 'remove',
   pushGateway: 'gcm' | 'apns' | 'apns2' | 'mpns',
-  environment: 'development' | 'production',
-  topic: string,
+  environment?: 'development' | 'production',
+  topic?: string,
   device: string,
   channels: Array<string>
 };
 
 type ModifyDeviceArgs = {
   pushGateway: 'gcm' | 'apns' | 'apns2' | 'mpns',
-  environment: 'development' | 'production',
-  topic: string,
+  environment?: 'development' | 'production',
+  topic?: string,
   device: string,
   channels: Array<string>
 };
 
 type ListChannelsArgs = {
   pushGateway: 'gcm' | 'apns' | 'apns2' | 'mpns',
-  environment: 'development' | 'production',
-  topic: string,
+  environment?: 'development' | 'production',
+  topic?: string,
   device: string,
 };
 
 type RemoveDeviceArgs = {
   pushGateway: 'gcm' | 'apns' | 'apns2' | 'mpns',
-  environment: 'development' | 'production',
-  topic: string,
+  environment?: 'development' | 'production',
+  topic?: string,
   device: string,
 };
 

--- a/src/core/flow_interfaces.js
+++ b/src/core/flow_interfaces.js
@@ -304,7 +304,7 @@ export type APNS2Target = {
 
 export type APNS2Configuration = {
   collapseId?: string,
-  date?: Date,
+  expirationDate?: Date,
   targets: Array<APNS2Target>
 }
 

--- a/src/core/flow_interfaces.js
+++ b/src/core/flow_interfaces.js
@@ -298,24 +298,32 @@ type ListChannelsResponse = {
 
 type ProvisionDeviceArgs = {
   operation: 'add' | 'remove',
-  pushGateway: 'gcm' | 'apns' | 'mpns',
+  pushGateway: 'gcm' | 'apns' | 'apns2' | 'mpns',
+  environment: 'development' | 'production',
+  topic: string,
   device: string,
   channels: Array<string>
 };
 
 type ModifyDeviceArgs = {
-  pushGateway: 'gcm' | 'apns' | 'mpns',
+  pushGateway: 'gcm' | 'apns' | 'apns2' | 'mpns',
+  environment: 'development' | 'production',
+  topic: string,
   device: string,
   channels: Array<string>
 };
 
 type ListChannelsArgs = {
-  pushGateway: 'gcm' | 'apns' | 'mpns',
+  pushGateway: 'gcm' | 'apns' | 'apns2' | 'mpns',
+  environment: 'development' | 'production',
+  topic: string,
   device: string,
 };
 
 type RemoveDeviceArgs = {
-  pushGateway: 'gcm' | 'apns' | 'mpns',
+  pushGateway: 'gcm' | 'apns' | 'apns2' | 'mpns',
+  environment: 'development' | 'production',
+  topic: string,
   device: string,
 };
 

--- a/src/core/pubnub-common.js
+++ b/src/core/pubnub-common.js
@@ -3,6 +3,7 @@
 import Config from './components/config';
 import Crypto from './components/cryptography/index';
 import SubscriptionManager from './components/subscription_manager';
+import NotificationsPayload from './components/push_payload';
 import ListenerManager from './components/listener_manager';
 import TokenManager from './components/token_manager';
 
@@ -527,6 +528,10 @@ export default class {
   networkUpDetected() {
     this._listenerManager.announceNetworkUp();
     this.reconnect();
+  }
+
+  static notificationPayload(title: ?string, body: ?string): NotificationsPayload {
+    return new NotificationsPayload(title, body);
   }
 
   static generateUUID(): string {

--- a/test/integration/endpoints/push.test.js
+++ b/test/integration/endpoints/push.test.js
@@ -49,6 +49,29 @@ describe('push endpoints', () => {
       );
     });
 
+    it('supports addition of multiple channels for apple (APNS2)', (done) => {
+      const scope = utils
+        .createNock()
+        .get('/v2/push/sub-key/mySubKey/devices-apns2/niceDevice')
+        .query({
+          add: 'a,b',
+          pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
+          environment: 'development',
+          topic: 'com.test.apns',
+          uuid: 'myUUID',
+        })
+        .reply(200, '[1, "Modified Channels"]');
+
+      pubnub.push.addChannels(
+        { channels: ['a', 'b'], device: 'niceDevice', pushGateway: 'apns2', topic: 'com.test.apns' },
+        (status) => {
+          assert.equal(status.error, false);
+          assert.equal(scope.isDone(), true);
+          done();
+        }
+      );
+    });
+
     it('supports addition of multiple channels for microsoft', (done) => {
       const scope = utils
         .createNock()
@@ -108,6 +131,29 @@ describe('push endpoints', () => {
 
       pubnub.push.listChannels(
         { device: 'coolDevice', pushGateway: 'apns' },
+        (status, response) => {
+          assert.equal(status.error, false);
+          assert.deepEqual(response.channels, ['ch1', 'ch2', 'ch3']);
+          assert.equal(scope.isDone(), true);
+          done();
+        }
+      );
+    });
+
+    it('supports channel listing for apple (APNS2)', (done) => {
+      const scope = utils
+        .createNock()
+        .get('/v2/push/sub-key/mySubKey/devices-apns2/coolDevice')
+        .query({
+          pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
+          environment: 'production',
+          topic: 'com.test.apns',
+          uuid: 'myUUID',
+        })
+        .reply(200, '["ch1", "ch2", "ch3"]');
+
+      pubnub.push.listChannels(
+        { device: 'coolDevice', pushGateway: 'apns2', environment: 'production', topic: 'com.test.apns' },
         (status, response) => {
           assert.equal(status.error, false);
           assert.deepEqual(response.channels, ['ch1', 'ch2', 'ch3']);
@@ -185,6 +231,29 @@ describe('push endpoints', () => {
       );
     });
 
+    it('supports removal of multiple channels for apple (APNS2)', (done) => {
+      const scope = utils
+        .createNock()
+        .get('/v2/push/sub-key/mySubKey/devices-apns2/niceDevice')
+        .query({
+          remove: 'a,b',
+          pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
+          environment: 'development',
+          topic: 'com.test.apns',
+          uuid: 'myUUID',
+        })
+        .reply(200, '[1, "Modified Channels"]');
+
+      pubnub.push.removeChannels(
+        { channels: ['a', 'b'], device: 'niceDevice', pushGateway: 'apns2', topic: 'com.test.apns' },
+        (status) => {
+          assert.equal(status.error, false);
+          assert.equal(scope.isDone(), true);
+          done();
+        }
+      );
+    });
+
     it('supports removal of multiple channels for microsoft', (done) => {
       const scope = utils
         .createNock()
@@ -249,6 +318,28 @@ describe('push endpoints', () => {
 
       pubnub.push.deleteDevice(
         { device: 'niceDevice', pushGateway: 'apns' },
+        (status) => {
+          assert.equal(status.error, false);
+          assert.equal(scope.isDone(), true);
+          done();
+        }
+      );
+    });
+
+    it('supports removal of device for apple (APNS2)', (done) => {
+      const scope = utils
+        .createNock()
+        .get('/v2/push/sub-key/mySubKey/devices-apns2/niceDevice/remove')
+        .query({
+          pnsdk: `PubNub-JS-Nodejs/${pubnub.getVersion()}`,
+          environment: 'production',
+          topic: 'com.test.apns',
+          uuid: 'myUUID',
+        })
+        .reply(200, '[1, "Modified Channels"]');
+
+      pubnub.push.deleteDevice(
+        { device: 'niceDevice', pushGateway: 'apns2', environment: 'production', topic: 'com.test.apns' },
         (status) => {
           assert.equal(status.error, false);
           assert.equal(scope.isDone(), true);

--- a/test/unit/notifications_payload.test.js
+++ b/test/unit/notifications_payload.test.js
@@ -1,4 +1,4 @@
-/* global describe, beforeEach, it, before, after */
+/* global describe, beforeEach, it */
 
 import assert from 'assert';
 import PubNub from '../../src/node/index';
@@ -119,9 +119,6 @@ describe('#notifications helper', () => {
 
       assert.throws(() => {
         builder.buildPayload(['apns2', 'fcm']);
-      }, {
-        name: 'ReferenceError',
-        message: 'APNS2 configuration is missing'
       });
     });
   });
@@ -133,7 +130,7 @@ describe('#notifications helper', () => {
       platformPayloadStorage = {};
     });
 
-    it('should set default payload structure', function () {
+    it('should set default payload structure', () => {
       let builder = new APNSNotificationPayload(platformPayloadStorage);
 
       assert(builder);
@@ -143,17 +140,18 @@ describe('#notifications helper', () => {
       assert.equal(Object.keys(platformPayloadStorage.aps.alert).length, 0);
     });
 
-    it('should set notification \'title\' and \'body\' with constructor', function () {
+    it('should set notification \'title\' and \'body\' with constructor', () => {
       let expectedTitle = PubNub.generateUUID();
       let expectedBody = PubNub.generateUUID();
 
       let builder = new APNSNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
 
+      assert(builder);
       assert.equal(platformPayloadStorage.aps.alert.title, expectedTitle);
       assert.equal(platformPayloadStorage.aps.alert.body, expectedBody);
     });
 
-    it('should set \'subtitle\'', function () {
+    it('should set \'subtitle\'', () => {
       let expectedSubtitle = PubNub.generateUUID();
 
       let builder = new APNSNotificationPayload(platformPayloadStorage);
@@ -162,7 +160,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.aps.alert.subtitle, expectedSubtitle);
     });
 
-    it('should not set \'subtitle\' if value is empty', function () {
+    it('should not set \'subtitle\' if value is empty', () => {
       let expectedSubtitle = '';
 
       let builder = new APNSNotificationPayload(platformPayloadStorage);
@@ -171,7 +169,7 @@ describe('#notifications helper', () => {
       assert(!platformPayloadStorage.aps.alert.subtitle);
     });
 
-    it('should set \'body\'', function () {
+    it('should set \'body\'', () => {
       let expectedBody = PubNub.generateUUID();
 
       let builder = new APNSNotificationPayload(platformPayloadStorage);
@@ -180,7 +178,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.aps.alert.body, expectedBody);
     });
 
-    it('should not set \'body\' if value is empty', function () {
+    it('should not set \'body\' if value is empty', () => {
       let expectedBody = '';
 
       let builder = new APNSNotificationPayload(platformPayloadStorage);
@@ -189,7 +187,7 @@ describe('#notifications helper', () => {
       assert(!platformPayloadStorage.aps.alert.body);
     });
 
-    it('should set \'badge\'', function () {
+    it('should set \'badge\'', () => {
       let expectedBadged = 16;
 
       let builder = new APNSNotificationPayload(platformPayloadStorage);
@@ -198,14 +196,14 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.aps.badge, expectedBadged);
     });
 
-    it('should not set \'badge\' if value is empty', function () {
+    it('should not set \'badge\' if value is empty', () => {
       let builder = new APNSNotificationPayload(platformPayloadStorage);
       builder.badge = null;
 
       assert(!platformPayloadStorage.aps.badge);
     });
 
-    it('should set \'sound\'', function () {
+    it('should set \'sound\'', () => {
       let expectedSound = PubNub.generateUUID();
 
       let builder = new APNSNotificationPayload(platformPayloadStorage);
@@ -214,7 +212,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.aps.sound, expectedSound);
     });
 
-    it('should not set \'sound\' if value is empty', function () {
+    it('should not set \'sound\' if value is empty', () => {
       let expectedSound = '';
 
       let builder = new APNSNotificationPayload(platformPayloadStorage);
@@ -223,13 +221,13 @@ describe('#notifications helper', () => {
       assert(!platformPayloadStorage.aps.sound);
     });
 
-    it('should return null when no data provided', function () {
+    it('should return null when no data provided', () => {
       let builder = new APNSNotificationPayload(platformPayloadStorage);
 
       assert.equal(builder.toObject(), null);
     });
 
-    it('should set \'content-available\' when set silenced', function () {
+    it('should set \'content-available\' when set silenced', () => {
       let builder = new APNSNotificationPayload(platformPayloadStorage, PubNub.generateUUID(), PubNub.generateUUID());
       builder.sound = PubNub.generateUUID();
       builder.badge = 20;
@@ -241,7 +239,7 @@ describe('#notifications helper', () => {
       assert(!builder.toObject().aps.alert);
     });
 
-    it('should return valid payload object', function () {
+    it('should return valid payload object', () => {
       let expectedSubtitle = PubNub.generateUUID();
       let expectedTitle = PubNub.generateUUID();
       let expectedSound = PubNub.generateUUID();
@@ -263,7 +261,7 @@ describe('#notifications helper', () => {
       assert.deepEqual(builder.toObject(), expectedPayload);
     });
 
-    it('should return valid payload for APNS over HTTP/2', function () {
+    it('should return valid payload for APNS over HTTP/2', () => {
       let expectedSubtitle = PubNub.generateUUID();
       let expectedTitle = PubNub.generateUUID();
       let expectedSound = PubNub.generateUUID();
@@ -303,17 +301,18 @@ describe('#notifications helper', () => {
       platformPayloadStorage = {};
     });
 
-    it('should set notification \'title\' and \'body\' with constructor', function () {
+    it('should set notification \'title\' and \'body\' with constructor', () => {
       let expectedTitle = PubNub.generateUUID();
       let expectedBody = PubNub.generateUUID();
 
       let builder = new MPNSNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
 
+      assert(builder);
       assert.equal(platformPayloadStorage.title, expectedTitle);
       assert.equal(platformPayloadStorage.back_content, expectedBody);
     });
 
-    it('should set \'back_title\' when \'subtitle\' passed', function () {
+    it('should set \'back_title\' when \'subtitle\' passed', () => {
       let expectedSubtitle = PubNub.generateUUID();
 
       let builder = new MPNSNotificationPayload(platformPayloadStorage);
@@ -322,7 +321,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.back_title, expectedSubtitle);
     });
 
-    it('should set \'back_title\'', function () {
+    it('should set \'back_title\'', () => {
       let expectedBackTitle = PubNub.generateUUID();
 
       let builder = new MPNSNotificationPayload(platformPayloadStorage);
@@ -331,7 +330,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.back_title, expectedBackTitle);
     });
 
-    it('should not set \'back_title\' if value is empty', function () {
+    it('should not set \'back_title\' if value is empty', () => {
       let expectedBackTitle = '';
 
       let builder = new MPNSNotificationPayload(platformPayloadStorage);
@@ -340,7 +339,7 @@ describe('#notifications helper', () => {
       assert(!platformPayloadStorage.back_title);
     });
 
-    it('should set \'back_content\' when \'body\' passed', function () {
+    it('should set \'back_content\' when \'body\' passed', () => {
       let expectedBody = PubNub.generateUUID();
 
       let builder = new MPNSNotificationPayload(platformPayloadStorage);
@@ -349,7 +348,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.back_content, expectedBody);
     });
 
-    it('should set \'back_content\' ', function () {
+    it('should set \'back_content\' ', () => {
       let expectedBackContent = PubNub.generateUUID();
 
       let builder = new MPNSNotificationPayload(platformPayloadStorage);
@@ -358,7 +357,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.back_content, expectedBackContent);
     });
 
-    it('should not set \'back_content\' if value is empty', function () {
+    it('should not set \'back_content\' if value is empty', () => {
       let expectedBackContent = '';
 
       let builder = new MPNSNotificationPayload(platformPayloadStorage);
@@ -367,7 +366,7 @@ describe('#notifications helper', () => {
       assert(!platformPayloadStorage.back_content);
     });
 
-    it('should set \'count\' when \'badge\' passed', function () {
+    it('should set \'count\' when \'badge\' passed', () => {
       let expectedBadge = 26;
 
       let builder = new MPNSNotificationPayload(platformPayloadStorage);
@@ -376,7 +375,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.count, expectedBadge);
     });
 
-    it('should set \'count\' ', function () {
+    it('should set \'count\' ', () => {
       let expectedCount = 26;
 
       let builder = new MPNSNotificationPayload(platformPayloadStorage);
@@ -385,20 +384,20 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.count, expectedCount);
     });
 
-    it('should not set \'count\' if value is empty', function () {
+    it('should not set \'count\' if value is empty', () => {
       let builder = new MPNSNotificationPayload(platformPayloadStorage);
       builder.count = null;
 
       assert(!platformPayloadStorage.count);
     });
 
-    it('should return null when no data provided', function () {
+    it('should return null when no data provided', () => {
       let builder = new MPNSNotificationPayload(platformPayloadStorage);
 
       assert.equal(builder.toObject(), null);
     });
 
-    it('should return valid payload object', function () {
+    it('should return valid payload object', () => {
       let expectedSubtitle = PubNub.generateUUID();
       let expectedTitle = PubNub.generateUUID();
       let expectedBody = PubNub.generateUUID();
@@ -427,7 +426,7 @@ describe('#notifications helper', () => {
       platformPayloadStorage = {};
     });
 
-    it('should set default payload structure', function () {
+    it('should set default payload structure', () => {
       let builder = new FCMNotificationPayload(platformPayloadStorage);
 
       assert(builder);
@@ -435,17 +434,18 @@ describe('#notifications helper', () => {
       assert(platformPayloadStorage.data);
     });
 
-    it('should set notification \'title\' and \'body\' with constructor', function () {
+    it('should set notification \'title\' and \'body\' with constructor', () => {
       let expectedTitle = PubNub.generateUUID();
       let expectedBody = PubNub.generateUUID();
 
-      new FCMNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
+      let builder = new FCMNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
 
+      assert(builder);
       assert.equal(platformPayloadStorage.notification.title, expectedTitle);
       assert.equal(platformPayloadStorage.notification.body, expectedBody);
     });
 
-    it('should not set \'subtitle\' because it is not supported' , function () {
+    it('should not set \'subtitle\' because it is not supported', () => {
       let expectedSubtitle = PubNub.generateUUID();
 
       let builder = new FCMNotificationPayload(platformPayloadStorage);
@@ -454,7 +454,7 @@ describe('#notifications helper', () => {
       assert.equal(Object.keys(platformPayloadStorage.notification).length, 0);
     });
 
-    it('should set \'body\'', function () {
+    it('should set \'body\'', () => {
       let expectedBody = PubNub.generateUUID();
 
       let builder = new FCMNotificationPayload(platformPayloadStorage);
@@ -463,7 +463,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.notification.body, expectedBody);
     });
 
-    it('should not set \'body\' if value is empty', function () {
+    it('should not set \'body\' if value is empty', () => {
       let expectedBody = '';
 
       let builder = new FCMNotificationPayload(platformPayloadStorage);
@@ -472,14 +472,14 @@ describe('#notifications helper', () => {
       assert(!platformPayloadStorage.notification.body);
     });
 
-    it('should not set \'badge\' because it is not supported' , function () {
+    it('should not set \'badge\' because it is not supported', () => {
       let builder = new FCMNotificationPayload(platformPayloadStorage);
       builder.badge = 30;
 
       assert.equal(Object.keys(platformPayloadStorage.notification).length, 0);
     });
 
-    it('should set \'sound\'', function () {
+    it('should set \'sound\'', () => {
       let expectedSound = PubNub.generateUUID();
 
       let builder = new FCMNotificationPayload(platformPayloadStorage);
@@ -488,7 +488,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.notification.sound, expectedSound);
     });
 
-    it('should not set \'sound\' if value is empty', function () {
+    it('should not set \'sound\' if value is empty', () => {
       let expectedSound = '';
 
       let builder = new FCMNotificationPayload(platformPayloadStorage);
@@ -497,7 +497,7 @@ describe('#notifications helper', () => {
       assert(!platformPayloadStorage.notification.sound);
     });
 
-    it('should set \'icon\'', function () {
+    it('should set \'icon\'', () => {
       let expectedIcon = PubNub.generateUUID();
 
       let builder = new FCMNotificationPayload(platformPayloadStorage);
@@ -506,7 +506,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.notification.icon, expectedIcon);
     });
 
-    it('should not set \'icon\' if value is empty', function () {
+    it('should not set \'icon\' if value is empty', () => {
       let expectedIcon = '';
 
       let builder = new FCMNotificationPayload(platformPayloadStorage);
@@ -515,7 +515,7 @@ describe('#notifications helper', () => {
       assert(!platformPayloadStorage.notification.icon);
     });
 
-    it('should set \'tag\'', function () {
+    it('should set \'tag\'', () => {
       let expectedTag = PubNub.generateUUID();
 
       let builder = new FCMNotificationPayload(platformPayloadStorage);
@@ -524,7 +524,7 @@ describe('#notifications helper', () => {
       assert.equal(platformPayloadStorage.notification.tag, expectedTag);
     });
 
-    it('should not set \'tag\' if value is empty', function () {
+    it('should not set \'tag\' if value is empty', () => {
       let expectedTag = '';
 
       let builder = new FCMNotificationPayload(platformPayloadStorage);
@@ -533,13 +533,13 @@ describe('#notifications helper', () => {
       assert(!platformPayloadStorage.notification.tag);
     });
 
-    it('should return null when no data provided', function () {
+    it('should return null when no data provided', () => {
       let builder = new FCMNotificationPayload(platformPayloadStorage);
 
       assert.equal(builder.toObject(), null);
     });
 
-    it('should move \'notification\' under \'data\' when set silenced', function () {
+    it('should move \'notification\' under \'data\' when set silenced', () => {
       let expectedTitle = PubNub.generateUUID();
       let expectedBody = PubNub.generateUUID();
       let expectedSound = PubNub.generateUUID();
@@ -557,7 +557,7 @@ describe('#notifications helper', () => {
       assert.deepEqual(builder.toObject().data.notification, expectedNotification);
     });
 
-    it('should return valid payload object', function () {
+    it('should return valid payload object', () => {
       let expectedTitle = PubNub.generateUUID();
       let expectedBody = PubNub.generateUUID();
       let expectedSound = PubNub.generateUUID();

--- a/test/unit/notifications_payload.test.js
+++ b/test/unit/notifications_payload.test.js
@@ -1,0 +1,578 @@
+/* global describe, beforeEach, it, before, after */
+
+import assert from 'assert';
+import PubNub from '../../src/node/index';
+import { APNSNotificationPayload, MPNSNotificationPayload, FCMNotificationPayload } from '../../src/core/components/push_payload';
+
+describe('#notifications helper', () => {
+  describe('payloads builder', () => {
+    it('should prepare platform specific builders', () => {
+      let expectedTitle = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+
+      let builder = PubNub.notificationPayload(expectedTitle, expectedBody);
+
+      assert(builder.apns);
+      assert(builder.mpns);
+      assert(builder.fcm);
+    });
+
+    it('should pass title and body to builders', () => {
+      let expectedTitle = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+
+      let builder = PubNub.notificationPayload(expectedTitle, expectedBody);
+
+      assert.equal(builder.apns.toObject().aps.alert.title, expectedTitle);
+      assert.equal(builder.apns.toObject().aps.alert.body, expectedBody);
+      assert.equal(builder.mpns.toObject().title, expectedTitle);
+      assert.equal(builder.mpns.toObject().back_content, expectedBody);
+      assert.equal(builder.fcm.toObject().notification.title, expectedTitle);
+      assert.equal(builder.fcm.toObject().notification.body, expectedBody);
+    });
+
+    it('should pass subtitle to builders', () => {
+      let expectedSubtitle = PubNub.generateUUID();
+
+      let builder = PubNub.notificationPayload(PubNub.generateUUID(), PubNub.generateUUID());
+      builder.subtitle = expectedSubtitle;
+
+      assert.equal(builder.apns.toObject().aps.alert.subtitle, expectedSubtitle);
+      assert.equal(builder.mpns.toObject().back_title, expectedSubtitle);
+      assert.equal(Object.keys(builder.fcm.notification).length, 2);
+    });
+
+    it('should pass badge to builders', () => {
+      let expectedBadge = 11;
+
+      let builder = PubNub.notificationPayload(PubNub.generateUUID(), PubNub.generateUUID());
+      builder.badge = expectedBadge;
+
+      assert.equal(builder.apns.toObject().aps.badge, expectedBadge);
+      assert.equal(builder.mpns.toObject().count, expectedBadge);
+      assert.equal(Object.keys(builder.fcm.notification).length, 2);
+    });
+
+    it('should pass sound to builders', () => {
+      let expectedSound = PubNub.generateUUID();
+
+      let builder = PubNub.notificationPayload(PubNub.generateUUID(), PubNub.generateUUID());
+      builder.sound = expectedSound;
+
+      assert.equal(builder.apns.toObject().aps.sound, expectedSound);
+      assert.equal(Object.keys(builder.mpns.payload).length, 2);
+      assert.equal(builder.fcm.toObject().notification.sound, expectedSound);
+    });
+
+    it('should set debug flag', () => {
+      let builder = PubNub.notificationPayload(PubNub.generateUUID(), PubNub.generateUUID());
+      builder.debugging = true;
+
+      assert.equal(builder.buildPayload(['apns']).pn_debug, true);
+    });
+
+    it('should provide payload for APNS and FCM', () => {
+      let expectedTitle = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+      let expectedPayload = {
+        pn_apns: {
+          aps: { alert: { title: expectedTitle, body: expectedBody } }
+        },
+        pn_gcm: {
+          notification: { title: expectedTitle, body: expectedBody }
+        }
+      };
+
+      let builder = PubNub.notificationPayload(expectedTitle, expectedBody);
+
+      assert.deepEqual(builder.buildPayload(['apns', 'fcm']), expectedPayload);
+    });
+
+    it('should provide payload for APNS2 and FCM', () => {
+      let expectedTitle = PubNub.generateUUID();
+      let expectedTopic = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+      let expectedPayload = {
+        pn_apns: {
+          aps: { alert: { title: expectedTitle, body: expectedBody } },
+          pn_push: [
+            {
+              auth_method: 'token',
+              targets: [{ environment: 'development', topic: expectedTopic }],
+              version: 'v2'
+            }
+          ]
+        },
+        pn_gcm: {
+          notification: { title: expectedTitle, body: expectedBody }
+        }
+      };
+
+      let builder = PubNub.notificationPayload(expectedTitle, expectedBody);
+      builder.apns.configurations = [{ targets: [{ topic: expectedTopic }] }];
+
+      assert.deepEqual(builder.buildPayload(['apns2', 'fcm']), expectedPayload);
+    });
+
+    it('should throw ReferenceError if APNS2 configurations is missing', () => {
+      let builder = PubNub.notificationPayload(PubNub.generateUUID(), PubNub.generateUUID());
+
+      assert.throws(() => {
+        builder.buildPayload(['apns2', 'fcm']);
+      }, {
+        name: 'ReferenceError',
+        message: 'APNS2 configuration is missing'
+      });
+    });
+  });
+
+  describe('apns builder', () => {
+    let platformPayloadStorage;
+
+    beforeEach(() => {
+      platformPayloadStorage = {};
+    });
+
+    it('should set default payload structure', function () {
+      let builder = new APNSNotificationPayload(platformPayloadStorage);
+
+      assert(builder);
+      assert(platformPayloadStorage.aps);
+      assert(platformPayloadStorage.aps.alert);
+      assert.equal(Object.keys(platformPayloadStorage.aps).length, 1);
+      assert.equal(Object.keys(platformPayloadStorage.aps.alert).length, 0);
+    });
+
+    it('should set notification \'title\' and \'body\' with constructor', function () {
+      let expectedTitle = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+
+      let builder = new APNSNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
+
+      assert.equal(platformPayloadStorage.aps.alert.title, expectedTitle);
+      assert.equal(platformPayloadStorage.aps.alert.body, expectedBody);
+    });
+
+    it('should set \'subtitle\'', function () {
+      let expectedSubtitle = PubNub.generateUUID();
+
+      let builder = new APNSNotificationPayload(platformPayloadStorage);
+      builder.subtitle = expectedSubtitle;
+
+      assert.equal(platformPayloadStorage.aps.alert.subtitle, expectedSubtitle);
+    });
+
+    it('should not set \'subtitle\' if value is empty', function () {
+      let expectedSubtitle = '';
+
+      let builder = new APNSNotificationPayload(platformPayloadStorage);
+      builder.subtitle = expectedSubtitle;
+
+      assert(!platformPayloadStorage.aps.alert.subtitle);
+    });
+
+    it('should set \'body\'', function () {
+      let expectedBody = PubNub.generateUUID();
+
+      let builder = new APNSNotificationPayload(platformPayloadStorage);
+      builder.body = expectedBody;
+
+      assert.equal(platformPayloadStorage.aps.alert.body, expectedBody);
+    });
+
+    it('should not set \'body\' if value is empty', function () {
+      let expectedBody = '';
+
+      let builder = new APNSNotificationPayload(platformPayloadStorage);
+      builder.body = expectedBody;
+
+      assert(!platformPayloadStorage.aps.alert.body);
+    });
+
+    it('should set \'badge\'', function () {
+      let expectedBadged = 16;
+
+      let builder = new APNSNotificationPayload(platformPayloadStorage);
+      builder.badge = expectedBadged;
+
+      assert.equal(platformPayloadStorage.aps.badge, expectedBadged);
+    });
+
+    it('should not set \'badge\' if value is empty', function () {
+      let builder = new APNSNotificationPayload(platformPayloadStorage);
+      builder.badge = null;
+
+      assert(!platformPayloadStorage.aps.badge);
+    });
+
+    it('should set \'sound\'', function () {
+      let expectedSound = PubNub.generateUUID();
+
+      let builder = new APNSNotificationPayload(platformPayloadStorage);
+      builder.sound = expectedSound;
+
+      assert.equal(platformPayloadStorage.aps.sound, expectedSound);
+    });
+
+    it('should not set \'sound\' if value is empty', function () {
+      let expectedSound = '';
+
+      let builder = new APNSNotificationPayload(platformPayloadStorage);
+      builder.sound = expectedSound;
+
+      assert(!platformPayloadStorage.aps.sound);
+    });
+
+    it('should return null when no data provided', function () {
+      let builder = new APNSNotificationPayload(platformPayloadStorage);
+
+      assert.equal(builder.toObject(), null);
+    });
+
+    it('should set \'content-available\' when set silenced', function () {
+      let builder = new APNSNotificationPayload(platformPayloadStorage, PubNub.generateUUID(), PubNub.generateUUID());
+      builder.sound = PubNub.generateUUID();
+      builder.badge = 20;
+      builder.silent = true;
+
+      assert.equal(builder.toObject().aps['content-available'], 1);
+      assert(!builder.toObject().aps.badge);
+      assert(!builder.toObject().aps.sound);
+      assert(!builder.toObject().aps.alert);
+    });
+
+    it('should return valid payload object', function () {
+      let expectedSubtitle = PubNub.generateUUID();
+      let expectedTitle = PubNub.generateUUID();
+      let expectedSound = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+      let expectedBadge = 26;
+      let expectedPayload = {
+        aps: {
+          alert: { title: expectedTitle, subtitle: expectedSubtitle, body: expectedBody },
+          badge: expectedBadge,
+          sound: expectedSound
+        }
+      };
+
+      let builder = new APNSNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
+      builder.subtitle = expectedSubtitle;
+      builder.badge = expectedBadge;
+      builder.sound = expectedSound;
+
+      assert.deepEqual(builder.toObject(), expectedPayload);
+    });
+
+    it('should return valid payload for APNS over HTTP/2', function () {
+      let expectedSubtitle = PubNub.generateUUID();
+      let expectedTitle = PubNub.generateUUID();
+      let expectedSound = PubNub.generateUUID();
+      let expectedTopic = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+      let expectedBadge = 26;
+      let expectedPayload = {
+        aps: {
+          alert: { title: expectedTitle, subtitle: expectedSubtitle, body: expectedBody },
+          badge: expectedBadge,
+          sound: expectedSound
+        },
+        pn_push: [
+          {
+            auth_method: 'token',
+            targets: [{ environment: 'development', topic: expectedTopic }],
+            version: 'v2'
+          }
+        ]
+      };
+
+      let builder = new APNSNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
+      builder.configurations = [{ targets: [{ topic: expectedTopic }] }];
+      builder.subtitle = expectedSubtitle;
+      builder._apnsPushType = 'apns2';
+      builder.badge = expectedBadge;
+      builder.sound = expectedSound;
+
+      assert.deepEqual(builder.toObject(), expectedPayload);
+    });
+  });
+
+  describe('mpns builder', () => {
+    let platformPayloadStorage;
+
+    beforeEach(() => {
+      platformPayloadStorage = {};
+    });
+
+    it('should set notification \'title\' and \'body\' with constructor', function () {
+      let expectedTitle = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+
+      let builder = new MPNSNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
+
+      assert.equal(platformPayloadStorage.title, expectedTitle);
+      assert.equal(platformPayloadStorage.back_content, expectedBody);
+    });
+
+    it('should set \'back_title\' when \'subtitle\' passed', function () {
+      let expectedSubtitle = PubNub.generateUUID();
+
+      let builder = new MPNSNotificationPayload(platformPayloadStorage);
+      builder.subtitle = expectedSubtitle;
+
+      assert.equal(platformPayloadStorage.back_title, expectedSubtitle);
+    });
+
+    it('should set \'back_title\'', function () {
+      let expectedBackTitle = PubNub.generateUUID();
+
+      let builder = new MPNSNotificationPayload(platformPayloadStorage);
+      builder.backTitle = expectedBackTitle;
+
+      assert.equal(platformPayloadStorage.back_title, expectedBackTitle);
+    });
+
+    it('should not set \'back_title\' if value is empty', function () {
+      let expectedBackTitle = '';
+
+      let builder = new MPNSNotificationPayload(platformPayloadStorage);
+      builder.backTitle = expectedBackTitle;
+
+      assert(!platformPayloadStorage.back_title);
+    });
+
+    it('should set \'back_content\' when \'body\' passed', function () {
+      let expectedBody = PubNub.generateUUID();
+
+      let builder = new MPNSNotificationPayload(platformPayloadStorage);
+      builder.body = expectedBody;
+
+      assert.equal(platformPayloadStorage.back_content, expectedBody);
+    });
+
+    it('should set \'back_content\' ', function () {
+      let expectedBackContent = PubNub.generateUUID();
+
+      let builder = new MPNSNotificationPayload(platformPayloadStorage);
+      builder.backContent = expectedBackContent;
+
+      assert.equal(platformPayloadStorage.back_content, expectedBackContent);
+    });
+
+    it('should not set \'back_content\' if value is empty', function () {
+      let expectedBackContent = '';
+
+      let builder = new MPNSNotificationPayload(platformPayloadStorage);
+      builder.backContent = expectedBackContent;
+
+      assert(!platformPayloadStorage.back_content);
+    });
+
+    it('should set \'count\' when \'badge\' passed', function () {
+      let expectedBadge = 26;
+
+      let builder = new MPNSNotificationPayload(platformPayloadStorage);
+      builder.badge = expectedBadge;
+
+      assert.equal(platformPayloadStorage.count, expectedBadge);
+    });
+
+    it('should set \'count\' ', function () {
+      let expectedCount = 26;
+
+      let builder = new MPNSNotificationPayload(platformPayloadStorage);
+      builder.count = expectedCount;
+
+      assert.equal(platformPayloadStorage.count, expectedCount);
+    });
+
+    it('should not set \'count\' if value is empty', function () {
+      let builder = new MPNSNotificationPayload(platformPayloadStorage);
+      builder.count = null;
+
+      assert(!platformPayloadStorage.count);
+    });
+
+    it('should return null when no data provided', function () {
+      let builder = new MPNSNotificationPayload(platformPayloadStorage);
+
+      assert.equal(builder.toObject(), null);
+    });
+
+    it('should return valid payload object', function () {
+      let expectedSubtitle = PubNub.generateUUID();
+      let expectedTitle = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+      let expectedCount = 26;
+      let expectedPayload = {
+        type: 'flip',
+        title: expectedTitle,
+        back_title: expectedSubtitle,
+        back_content: expectedBody,
+        count: expectedCount
+      };
+
+      let builder = new MPNSNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
+      builder.subtitle = expectedSubtitle;
+      builder.count = expectedCount;
+      builder.type = 'flip';
+
+      assert.deepEqual(builder.toObject(), expectedPayload);
+    });
+  });
+
+  describe('fcm builder', () => {
+    let platformPayloadStorage;
+
+    beforeEach(() => {
+      platformPayloadStorage = {};
+    });
+
+    it('should set default payload structure', function () {
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+
+      assert(builder);
+      assert(platformPayloadStorage.notification);
+      assert(platformPayloadStorage.data);
+    });
+
+    it('should set notification \'title\' and \'body\' with constructor', function () {
+      let expectedTitle = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+
+      new FCMNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
+
+      assert.equal(platformPayloadStorage.notification.title, expectedTitle);
+      assert.equal(platformPayloadStorage.notification.body, expectedBody);
+    });
+
+    it('should not set \'subtitle\' because it is not supported' , function () {
+      let expectedSubtitle = PubNub.generateUUID();
+
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+      builder.subtitle = expectedSubtitle;
+
+      assert.equal(Object.keys(platformPayloadStorage.notification).length, 0);
+    });
+
+    it('should set \'body\'', function () {
+      let expectedBody = PubNub.generateUUID();
+
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+      builder.body = expectedBody;
+
+      assert.equal(platformPayloadStorage.notification.body, expectedBody);
+    });
+
+    it('should not set \'body\' if value is empty', function () {
+      let expectedBody = '';
+
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+      builder.body = expectedBody;
+
+      assert(!platformPayloadStorage.notification.body);
+    });
+
+    it('should not set \'badge\' because it is not supported' , function () {
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+      builder.badge = 30;
+
+      assert.equal(Object.keys(platformPayloadStorage.notification).length, 0);
+    });
+
+    it('should set \'sound\'', function () {
+      let expectedSound = PubNub.generateUUID();
+
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+      builder.sound = expectedSound;
+
+      assert.equal(platformPayloadStorage.notification.sound, expectedSound);
+    });
+
+    it('should not set \'sound\' if value is empty', function () {
+      let expectedSound = '';
+
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+      builder.sound = expectedSound;
+
+      assert(!platformPayloadStorage.notification.sound);
+    });
+
+    it('should set \'icon\'', function () {
+      let expectedIcon = PubNub.generateUUID();
+
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+      builder.icon = expectedIcon;
+
+      assert.equal(platformPayloadStorage.notification.icon, expectedIcon);
+    });
+
+    it('should not set \'icon\' if value is empty', function () {
+      let expectedIcon = '';
+
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+      builder.icon = expectedIcon;
+
+      assert(!platformPayloadStorage.notification.icon);
+    });
+
+    it('should set \'tag\'', function () {
+      let expectedTag = PubNub.generateUUID();
+
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+      builder.tag = expectedTag;
+
+      assert.equal(platformPayloadStorage.notification.tag, expectedTag);
+    });
+
+    it('should not set \'tag\' if value is empty', function () {
+      let expectedTag = '';
+
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+      builder.tag = expectedTag;
+
+      assert(!platformPayloadStorage.notification.tag);
+    });
+
+    it('should return null when no data provided', function () {
+      let builder = new FCMNotificationPayload(platformPayloadStorage);
+
+      assert.equal(builder.toObject(), null);
+    });
+
+    it('should move \'notification\' under \'data\' when set silenced', function () {
+      let expectedTitle = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+      let expectedSound = PubNub.generateUUID();
+      let expectedNotification = {
+        title: expectedTitle,
+        body: expectedBody,
+        sound: expectedSound
+      };
+
+      let builder = new FCMNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
+      builder.sound = expectedSound;
+      builder.silent = true;
+
+      assert(!builder.toObject().notification);
+      assert.deepEqual(builder.toObject().data.notification, expectedNotification);
+    });
+
+    it('should return valid payload object', function () {
+      let expectedTitle = PubNub.generateUUID();
+      let expectedBody = PubNub.generateUUID();
+      let expectedSound = PubNub.generateUUID();
+      let expectedPayload = {
+        notification: {
+          title: expectedTitle,
+          body: expectedBody,
+          sound: expectedSound
+        }
+      };
+
+      let builder = new FCMNotificationPayload(platformPayloadStorage, expectedTitle, expectedBody);
+      builder.sound = expectedSound;
+
+      assert.deepEqual(builder.toObject(), expectedPayload);
+    });
+  });
+});


### PR DESCRIPTION
Added methods which provide access APNS2 endpoints to:
* add device to channels
* list device channels
* remove device from channels
* remove device from all channels
