### PR TITLE
Fix infinite heartbeat interval if presenceTimeout is set to 0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pubnub",
-  "version": "4.27.3",
+  "version": "4.27.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/core/components/config.js
+++ b/src/core/components/config.js
@@ -196,7 +196,7 @@ export default class {
     // set config on beacon (https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) usage
     this.setSendBeaconConfig(setup.useSendBeacon || true);
     // how long the SDK will report the client to be alive before issuing a timeout
-    if (setup.presenceTimeout) {
+    if (Number.isInteger(setup.presenceTimeout)) {
       this.setPresenceTimeout(setup.presenceTimeout);
     } else {
       this._presenceTimeout = PRESENCE_TIMEOUT_DEFAULT;


### PR DESCRIPTION
- If presenceTime out is set to 0 and heartbeatInterval is not provided during initialization, heartbeatInterval remain undefined which causes heartbeat interval to execute in infinite loop causing performance issues in apps.

**Question: What should be the value of HeartbeatInterval when presenceTimeout is 0 ?** 