### PR TITLE
Relax requirement for objects v2 membership get UUID param

### DIFF
--- a/src/core/endpoints/objects/membership/get.js
+++ b/src/core/endpoints/objects/membership/get.js
@@ -19,13 +19,9 @@ export type GetMembershipsResult = {|
 const endpoint: EndpointConfig<GetMembershipsParams, GetMembershipsResult> = {
   getOperation: () => operationConstants.PNGetMembershipsOperation,
 
-  validateParams: (_, params) => {
-    if (!params?.uuid) {
-      return 'UUID cannot be empty';
-    }
-  },
+  validateParams: () => {},
 
-  getURL: ({ config }, params) => `/v2/objects/${config.subscribeKey}/uuids/${params.uuid}/channels`,
+  getURL: ({ config }, params) => `/v2/objects/${config.subscribeKey}/uuids/${params.uuid ?? config.getUUID()}/channels`,
 
   getRequestTimeout: ({ config }) => config.getTransactionTimeout(),
 


### PR DESCRIPTION
The docs indicate that the UUID being omited as a param when calling
getMemberships on objects v2 should use the client UUID. The validation
was a bit too strict, so this relaxes that. We also update the code
to use the client UUID by default if the params UUID is  missing.