### PR TITLE
fix React Native- Couldn't construct a file out of supplied options

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "main": "./lib/node/index.js",
   "react-native": "./lib/react_native/index.js",
+  "metro": "./lib/react_native/index.js",
   "nativescript": "./lib/nativescript/index.js",
   "browser": "./dist/web/pubnub.min.js",
   "repository": {


### PR DESCRIPTION
Fix for the issue where new versions of the Metro bundler used by React Native uses a different entry point than older versions.