### PR TITLE
feat: optional param withHeartbeat to set state through heartbeat endpoint.

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,10 +1,5 @@
 ---
 changelog:
-  - date: 2023-06-14
-    version: v7.2.3
-    changes:
-      - type: feature
-        text: "Added optional param withHeartbeat to set state through heartbeat endpoint."
   - date: 2022-12-12
     version: v7.2.2
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## v7.2.3
-June 14 2023
-
-#### Added
-- Added optional param withHeartbeat to set state through heartbeat endpoint.
-
 ## v7.2.2
 December 12 2022
 

--- a/src/core/endpoints/presence/set_state.js
+++ b/src/core/endpoints/presence/set_state.js
@@ -1,6 +1,3 @@
-/*       */
-
-import { SetStateArguments, SetStateResponse, ModulesInject } from '../../flow_interfaces';
 import operationConstants from '../../constants/operations';
 import utils from '../../utils';
 


### PR DESCRIPTION
feat: Support for optional param withHeartbeat to set state through heartbeat endpoint.

Added optional param `withHeartbeat` to set state through heartbeat endpoint.