### PR TITLE
feature: cleanup SDK on navigation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pubnub",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "author": "PubNub <support@pubnub.com>",
   "description": "Publish & Subscribe Real-time Messaging with PubNub",
   "scripts": {

--- a/src/web/components/configuration.ts
+++ b/src/web/components/configuration.ts
@@ -19,6 +19,12 @@ import { ICryptoModule } from '../../core/interfaces/crypto-module';
 const LISTEN_TO_BROWSER_NETWORK_EVENTS = true;
 
 /**
+ * If set to `true`, SDK will attempt to destroy itself when the browser begins navigation via the beforeunload event.
+ * Fixes issues with Safari memory leaks when refreshing, or navigating away and returning with the browser back button.
+ */
+const CLEANUP_ON_BROWSER_NAVIGATION = false;
+
+/**
  * Whether verbose logging should be enabled for `Subscription` worker to print debug messages or not.
  */
 const SUBSCRIPTION_WORKER_LOG_VERBOSITY = false;
@@ -41,6 +47,16 @@ export type PubNubConfiguration = UserConfiguration & {
    * @default `true`
    */
   listenToBrowserNetworkEvents?: boolean;
+
+  /**
+   * If set to `true`, SDK will attempt to destroy itself when the browser begins navigation via the
+   * beforeunload event.
+   *
+   * This fixes issues with Safari memory leaks when refreshing, or navigating away and returning with the back button.
+   *
+   * @default `false`
+   */
+  cleanupOnNavigationEvent?: boolean;
 
   /**
    * Path to the hosted PubNub `Subscription` service worker.
@@ -116,6 +132,7 @@ export const setDefaults = (configuration: PubNubConfiguration): PubNubConfigura
     ...setBaseDefaults(configuration),
     // Set platform-specific options.
     listenToBrowserNetworkEvents: configuration.listenToBrowserNetworkEvents ?? LISTEN_TO_BROWSER_NETWORK_EVENTS,
+    cleanupOnNavigationEvent: configuration.cleanupOnNavigationEvent ?? CLEANUP_ON_BROWSER_NAVIGATION,
     subscriptionWorkerUrl: configuration.subscriptionWorkerUrl,
     subscriptionWorkerLogVerbosity: configuration.subscriptionWorkerLogVerbosity ?? SUBSCRIPTION_WORKER_LOG_VERBOSITY,
     keepAlive: configuration.keepAlive ?? KEEP_ALIVE,

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -136,6 +136,12 @@ export default class PubNub extends PubNubCore<ArrayBuffer | string, PubNubFileP
         this.networkUpDetected();
       });
     }
+
+    if (configuration.cleanupOnNavigationEvent ?? false) {
+      window.addEventListener('beforeunload', () => {
+        this.destroy(true);
+      });
+    }
   }
 
   private networkDownDetected() {


### PR DESCRIPTION
## Cleanup on navigation event
Fixes https://github.com/pubnub/javascript/issues/398 by adding an optional window listener to the `beforeunload` event. Utilizes the `destroy` method in the SDK similar to the `networkDownDetected` function.

Alleviates runaway garbage collection in tested Safari verison `Version 17.5 (19618.2.12.11.6)` 

![Screenshot 2024-11-20 at 10 49 35 AM](https://github.com/user-attachments/assets/abc663bf-a869-43cc-8749-fe5f504b0556)
![Screenshot 2024-11-20 at 10 49 50 AM](https://github.com/user-attachments/assets/663e3ce7-cba1-4944-bb68-03ac9dc1a286)

Optional value as to not introduce breaking changes for any users.

## Usage
Pubnub Chat users can utilize this function via the constructor:

```ts
Chat.init({
    // ... other options
    cleanupOnNavigationEvent: true // this flag
}).
```