### PR TITLE
deps: upgrade form-data to 4.0.4 for vulnerability fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pubnub",
-  "version": "9.7.0",
+  "version": "9.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pubnub",
-      "version": "9.7.0",
+      "version": "9.8.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "agentkeepalive": "^3.5.2",
@@ -14,7 +14,7 @@
         "cbor-js": "^0.1.0",
         "cbor-sync": "^1.0.4",
         "fflate": "^0.8.2",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "lil-uuid": "^0.1.1",
         "node-fetch": "^2.7.0",
         "proxy-agent": "^6.3.0",
@@ -7930,14 +7930,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "cbor-js": "^0.1.0",
     "cbor-sync": "^1.0.4",
     "fflate": "^0.8.2",
-    "form-data": "^4.0.0",
+    "form-data": "^4.0.4",
     "lil-uuid": "^0.1.1",
     "node-fetch": "^2.7.0",
     "proxy-agent": "^6.3.0",


### PR DESCRIPTION
build: upgrade form-data dependency to address potential vulnerability issue.

upgraded `form-data` dependency to version 4.0.4 to address potential vulnerability issue.