### PR TITLE
Issue 474 fallback to encryption for React Native when CipherKey is present

### DIFF
--- a/lib/core/components/cryptography/legacy-crypto-module-adapter.js
+++ b/lib/core/components/cryptography/legacy-crypto-module-adapter.js
@@ -1,0 +1,62 @@
+"use strict";
+/**
+ * ICryptoModule adapter that delegates to the legacy Crypto implementation.
+ *
+ * This bridges the RN path to the endpoints that expect an ICryptoModule when
+ * only a cipherKey is provided.
+ */
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const buffer_1 = require("buffer");
+class LegacyCryptoModuleAdapter {
+    constructor(legacy) {
+        this.legacy = legacy;
+    }
+    // Allow SDK to update logger on the underlying legacy crypto.
+    set logger(logger) {
+        // legacy logger setter accepts LoggerManager | undefined
+        this.legacy.logger = logger;
+    }
+    // --------------------------------------------------------
+    // --------------------- Encryption -----------------------
+    // --------------------------------------------------------
+    encrypt(data) {
+        const plaintext = typeof data === 'string' ? data : buffer_1.Buffer.from(new Uint8Array(data)).toString('utf8');
+        // Legacy crypto returns a base64 string.
+        return this.legacy.encrypt(plaintext);
+    }
+    encryptFile(_file, _File) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Not used on RN when cipherKey is set: file endpoints take the cipherKey + cryptography path.
+            return undefined;
+        });
+    }
+    // --------------------------------------------------------
+    // --------------------- Decryption -----------------------
+    // --------------------------------------------------------
+    decrypt(data) {
+        let ciphertextB64;
+        if (typeof data === 'string')
+            ciphertextB64 = data;
+        else
+            ciphertextB64 = buffer_1.Buffer.from(new Uint8Array(data)).toString('base64');
+        const decrypted = this.legacy.decrypt(ciphertextB64);
+        // Legacy decrypt returns object or string; ICryptoModule allows returning ArrayBuffer | Payload | null.
+        return decrypted;
+    }
+    decryptFile(_file, _File) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Not used on RN when cipherKey is set: file endpoints take the cipherKey + cryptography path.
+            return undefined;
+        });
+    }
+}
+exports.default = LegacyCryptoModuleAdapter;

--- a/lib/react_native/index.js
+++ b/lib/react_native/index.js
@@ -15,6 +15,7 @@ const middleware_1 = require("../transport/middleware");
 const base64_codec_1 = require("../core/components/base64_codec");
 const react_native_1 = __importDefault(require("../file/modules/react-native"));
 const cryptography_1 = __importDefault(require("../core/components/cryptography"));
+const legacy_crypto_module_adapter_1 = __importDefault(require("../core/components/cryptography/legacy-crypto-module-adapter"));
 const pubnub_common_1 = require("../core/pubnub-common");
 const configuration_2 = require("./configuration");
 const common_1 = __importDefault(require("../cbor/common"));
@@ -39,7 +40,23 @@ class PubNub extends pubnub_common_1.PubNubCore {
         if (process.env.FILE_SHARING_MODULE !== 'disabled')
             platformConfiguration.PubNubFile = react_native_1.default;
         // Prepare full client configuration.
-        const clientConfiguration = (0, configuration_1.makeConfiguration)(platformConfiguration);
+        // Install a CryptoModule on RN when a cipherKey is provided by adapting legacy Crypto.
+        const clientConfiguration = (0, configuration_1.makeConfiguration)(platformConfiguration, (cryptoConfiguration) => {
+            if (!cryptoConfiguration.cipherKey)
+                return undefined;
+            if (process.env.CRYPTO_MODULE !== 'disabled') {
+                const legacy = new cryptography_1.default({
+                    secretKey: platformConfiguration.secretKey,
+                    cipherKey: cryptoConfiguration.cipherKey,
+                    useRandomIVs: platformConfiguration.useRandomIVs,
+                    customEncrypt: platformConfiguration.customEncrypt,
+                    customDecrypt: platformConfiguration.customDecrypt,
+                    logger: cryptoConfiguration.logger,
+                });
+                return new legacy_crypto_module_adapter_1.default(legacy);
+            }
+            return undefined;
+        });
         // Prepare Token manager.
         let tokenManager;
         if (process.env.CRYPTO_MODULE !== 'disabled') {
@@ -63,6 +80,7 @@ class PubNub extends pubnub_common_1.PubNubCore {
         const transportMiddleware = new middleware_1.PubNubMiddleware({
             clientConfiguration,
             tokenManager,
+            shaHMAC: process.env.CRYPTO_MODULE !== 'disabled' ? crypto === null || crypto === void 0 ? void 0 : crypto.HMACSHA256.bind(crypto) : undefined,
             transport: new react_native_transport_1.ReactNativeTransport(clientConfiguration.logger(), clientConfiguration.keepAlive),
         });
         super({

--- a/src/core/components/cryptography/legacy-crypto-module-adapter.ts
+++ b/src/core/components/cryptography/legacy-crypto-module-adapter.ts
@@ -1,0 +1,57 @@
+/**
+ * ICryptoModule adapter that delegates to the legacy Crypto implementation.
+ *
+ * This bridges the RN path to the endpoints that expect an ICryptoModule when
+ * only a cipherKey is provided.
+ */
+
+import type { ICryptoModule } from '../../interfaces/crypto-module';
+import type { PubNubFileConstructor, PubNubFileInterface } from '../../types/file';
+import type { Payload } from '../../types/api';
+import type { LoggerManager } from '../logger-manager';
+import LegacyCrypto from './index';
+import { Buffer } from 'buffer';
+
+export default class LegacyCryptoModuleAdapter implements ICryptoModule {
+  constructor(private readonly legacy: LegacyCrypto) {}
+
+  set logger(logger: LoggerManager) {
+    this.legacy.logger = logger;
+  }
+
+  // --------------------------------------------------------
+  // --------------------- Encryption -----------------------
+  // --------------------------------------------------------
+  encrypt(data: ArrayBuffer | string): ArrayBuffer | string {
+    const plaintext = typeof data === 'string' ? data : Buffer.from(new Uint8Array(data)).toString('utf8');
+    return this.legacy.encrypt(plaintext) as string;
+  }
+
+  async encryptFile(
+    _file: PubNubFileInterface,
+    _File: PubNubFileConstructor<PubNubFileInterface, unknown>,
+  ): Promise<PubNubFileInterface | undefined> {
+    // Not used on RN when cipherKey is set: file endpoints take the cipherKey + cryptography path.
+    return undefined;
+  }
+
+  // --------------------------------------------------------
+  // --------------------- Decryption -----------------------
+  // --------------------------------------------------------
+  decrypt(data: ArrayBuffer | string): ArrayBuffer | Payload | null {
+    let ciphertextB64: string;
+    if (typeof data === 'string') ciphertextB64 = data;
+    else ciphertextB64 = Buffer.from(new Uint8Array(data)).toString('base64');
+
+    const decrypted = this.legacy.decrypt(ciphertextB64);
+    return decrypted as Payload | null;
+  }
+
+  async decryptFile(
+    _file: PubNubFileInterface,
+    _File: PubNubFileConstructor<PubNubFileInterface, unknown>,
+  ): Promise<PubNubFileInterface | undefined> {
+    // Not used on RN when cipherKey is set: file endpoints take the cipherKey + cryptography path.
+    return undefined;
+  }
+}

--- a/src/react_native/index.ts
+++ b/src/react_native/index.ts
@@ -14,6 +14,8 @@ import { decode } from '../core/components/base64_codec';
 import PubNubFile from '../file/modules/react-native';
 import { PubNubConfiguration } from './configuration';
 import Crypto from '../core/components/cryptography';
+import LegacyCryptoModuleAdapter from '../core/components/cryptography/legacy-crypto-module-adapter';
+import type { CryptorConfiguration, ICryptoModule } from '../core/interfaces/crypto-module';
 import { PubNubCore } from '../core/pubnub-common';
 import { setDefaults } from './configuration';
 import Cbor from '../cbor/common';
@@ -96,7 +98,26 @@ export default class PubNub extends PubNubCore<null, PubNubFileParameters> {
     if (process.env.FILE_SHARING_MODULE !== 'disabled') platformConfiguration.PubNubFile = PubNubFile;
 
     // Prepare full client configuration.
-    const clientConfiguration = makeConfiguration(platformConfiguration);
+    // Install a CryptoModule on RN when a cipherKey is provided by adapting legacy Crypto.
+    const clientConfiguration = makeConfiguration(
+      platformConfiguration,
+      (cryptoConfiguration: CryptorConfiguration): ICryptoModule | undefined => {
+        if (!cryptoConfiguration.cipherKey) return undefined;
+
+        if (process.env.CRYPTO_MODULE !== 'disabled') {
+          const legacy = new Crypto({
+            secretKey: platformConfiguration.secretKey,
+            cipherKey: cryptoConfiguration.cipherKey,
+            useRandomIVs: platformConfiguration.useRandomIVs,
+            customEncrypt: platformConfiguration.customEncrypt,
+            customDecrypt: platformConfiguration.customDecrypt,
+            logger: cryptoConfiguration.logger,
+          });
+          return new LegacyCryptoModuleAdapter(legacy);
+        }
+        return undefined;
+      },
+    );
 
     // Prepare Token manager.
     let tokenManager: TokenManager | undefined;
@@ -125,6 +146,7 @@ export default class PubNub extends PubNubCore<null, PubNubFileParameters> {
     const transportMiddleware = new PubNubMiddleware({
       clientConfiguration,
       tokenManager,
+      shaHMAC: process.env.CRYPTO_MODULE !== 'disabled' ? crypto?.HMACSHA256.bind(crypto) : undefined,
       transport: new ReactNativeTransport(clientConfiguration.logger(), clientConfiguration.keepAlive),
     });
 


### PR DESCRIPTION
As outlined in [Issue 474](https://github.com/pubnub/javascript/issues/474), when a cipherKey value is passed in the configuration arguments, instead of using the legacy crypto functionality like in other areas, there is a silent fallback to plaintext as the new design relies on the presence of a defined ICryptoModule.  This PR gives a fallback to the legacy encryption methods when a cipherkey is passed in, as this is likely the expectation of users, particularly coming from earlier versions of the library, then passing in this value.

To accomplish this, there are two small changes:

- Adding a simple adapter that wraps the legacy functions in a compatiable ICryptoModule
- When a cipherKey is passed in the constructor, the adapter is utilized 